### PR TITLE
feat: schema cache + extraction hot-path optimizations

### DIFF
--- a/.github/workflows/PrValidation.yml
+++ b/.github/workflows/PrValidation.yml
@@ -1,0 +1,82 @@
+#
+# PR validation: build, SQLLogic tests, and write-path benchmark gate.
+#
+name: PR Validation
+
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'test/**'
+      - 'scripts/**'
+      - 'CMakeLists.txt'
+      - 'extension_config.cmake'
+      - 'Makefile'
+      - '.github/workflows/PrValidation.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/**'
+      - 'test/**'
+      - 'scripts/**'
+      - 'CMakeLists.txt'
+  workflow_dispatch:
+
+concurrency:
+  group: pr-validation-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    name: Build & SQLLogic tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build ccache
+
+      - name: Build release
+        run: GEN=ninja make release
+
+      - name: Run SQLLogic tests
+        run: make test
+
+  write-benchmark-gate:
+    name: Write A/B benchmark gate
+    runs-on: ubuntu-24.04
+    needs: build-and-test
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build ccache
+
+      - name: Build release
+        run: GEN=ninja make release
+
+      - name: Run A/B stats (3 rounds) and check regression threshold
+        env:
+          ROUNDS: 3
+          WRITE_REGRESSION_MAX_PCT: 10
+        run: ./scripts/ci_benchmark_gate.sh
+
+      - name: Upload benchmark artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: vs-release-benchmark
+          path: |
+            agent_planning/bench/vs_release/ab_stats_results.txt
+            agent_planning/bench/vs_release/ab_stats_rounds.csv

--- a/agent_planning/bench/compare_storage_types.sh
+++ b/agent_planning/bench/compare_storage_types.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+DUCKDB="${DUCKDB:-$(dirname "$0")/../../build/release/duckdb}"
+NDJSON_100K="/tmp/rawduck_compare_100k.ndjson"
+NDJSON_500K="/tmp/rawduck_compare_500k.ndjson"
+ROUNDS="${ROUNDS:-5}"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+CSV_OPTS="columns={'line':'VARCHAR'}, auto_detect=false, header=false, delim=E'\\\\x01', quote=''"
+
+measure_ms() {
+    local start end
+    start=$(date +%s%N)
+    eval "$1"
+    end=$(date +%s%N)
+    echo $(( (end - start) / 1000000 ))
+}
+
+best_of() {
+    local cmd="$1" rounds="$2" best=999999
+    for ((r=1; r<=rounds; r++)); do
+        local ms
+        ms=$(measure_ms "$cmd")
+        if (( ms < best )); then best=$ms; fi
+    done
+    echo "$best"
+}
+
+disk_size() {
+    local db="$1"
+    local total=0
+    for f in "$db" "$db.wal"; do
+        if [ -f "$f" ]; then
+            total=$((total + $(stat -c%s "$f")))
+        fi
+    done
+    echo $total
+}
+
+ddb() {
+    local db="$1"
+    shift
+    echo "$@" | "$DUCKDB" "$db" >/dev/null 2>&1
+}
+
+ddb_val() {
+    local db="$1"
+    shift
+    echo "$@" | "$DUCKDB" "$db" -csv -noheader 2>/dev/null | head -1
+}
+
+run_benchmark() {
+    local label="$1" ndjson="$2" rows="$3"
+    local db
+
+    echo ""
+    echo "=== $label ($rows rows) ==="
+    echo ""
+
+    # --- RawDuck shredded ---
+    db="$TMPDIR/rawduck_${rows}.duckdb"
+    local rawduck_write
+    rawduck_write=$(best_of "rm -f '$db' '$db.wal'; ddb '$db' \"FROM raw_ingest_file('events', '$ndjson');
+CHECKPOINT;\"" "$ROUNDS")
+
+    local rawduck_disk rawduck_count
+    rawduck_disk=$(disk_size "$db")
+    rawduck_count=$(ddb_val "$db" "SELECT count(*) FROM events;")
+
+    local rawduck_read_filter rawduck_read_group rawduck_read_scan
+    rawduck_read_filter=$(best_of "ddb '$db' \"SELECT count(*) FROM events WHERE score > 50;\"" "$ROUNDS")
+    rawduck_read_group=$(best_of "ddb '$db' \"SELECT tag, count(*), avg(score) FROM events GROUP BY tag;\"" "$ROUNDS")
+    rawduck_read_scan=$(best_of "ddb '$db' \"SELECT count(*), sum(id) FROM events;\"" "$ROUNDS")
+
+    # --- JSON column ---
+    db="$TMPDIR/json_${rows}.duckdb"
+    local json_write
+    json_write=$(best_of "rm -f '$db' '$db.wal'; ddb '$db' \"CREATE TABLE events (data JSON);
+INSERT INTO events SELECT line::JSON FROM read_csv('$ndjson', $CSV_OPTS);
+CHECKPOINT;\"" "$ROUNDS")
+
+    local json_disk json_count
+    json_disk=$(disk_size "$db")
+    json_count=$(ddb_val "$db" "SELECT count(*) FROM events;")
+
+    local json_read_filter json_read_group json_read_scan
+    json_read_filter=$(best_of "ddb '$db' \"SELECT count(*) FROM events WHERE (data->>'score')::DOUBLE > 50;\"" "$ROUNDS")
+    json_read_group=$(best_of "ddb '$db' \"SELECT data->>'tag' as tag, count(*), avg((data->>'score')::DOUBLE) FROM events GROUP BY tag;\"" "$ROUNDS")
+    json_read_scan=$(best_of "ddb '$db' \"SELECT count(*), sum((data->>'id')::BIGINT) FROM events;\"" "$ROUNDS")
+
+    # --- VARCHAR column ---
+    db="$TMPDIR/varchar_${rows}.duckdb"
+    local varchar_write
+    varchar_write=$(best_of "rm -f '$db' '$db.wal'; ddb '$db' \"CREATE TABLE events (data VARCHAR);
+INSERT INTO events SELECT line FROM read_csv('$ndjson', $CSV_OPTS);
+CHECKPOINT;\"" "$ROUNDS")
+
+    local varchar_disk varchar_count
+    varchar_disk=$(disk_size "$db")
+    varchar_count=$(ddb_val "$db" "SELECT count(*) FROM events;")
+
+    local varchar_read_filter varchar_read_group varchar_read_scan
+    varchar_read_filter=$(best_of "ddb '$db' \"SELECT count(*) FROM events WHERE (data::JSON->>'score')::DOUBLE > 50;\"" "$ROUNDS")
+    varchar_read_group=$(best_of "ddb '$db' \"SELECT data::JSON->>'tag' as tag, count(*), avg((data::JSON->>'score')::DOUBLE) FROM events GROUP BY tag;\"" "$ROUNDS")
+    varchar_read_scan=$(best_of "ddb '$db' \"SELECT count(*), sum((data::JSON->>'id')::BIGINT) FROM events;\"" "$ROUNDS")
+
+    # --- Print results ---
+    echo "Row counts: RawDuck=$rawduck_count  JSON=$json_count  VARCHAR=$varchar_count"
+    echo ""
+
+    local rw_rps jw_rps vw_rps
+    rw_rps=$(python3 -c "print(f'{$rows * 1000 / max($rawduck_write, 1):,.0f}')")
+    jw_rps=$(python3 -c "print(f'{$rows * 1000 / max($json_write, 1):,.0f}')")
+    vw_rps=$(python3 -c "print(f'{$rows * 1000 / max($varchar_write, 1):,.0f}')")
+
+    local rd_kb jd_kb vd_kb
+    rd_kb=$(python3 -c "print(f'{$rawduck_disk/1024:.0f}')")
+    jd_kb=$(python3 -c "print(f'{$json_disk/1024:.0f}')")
+    vd_kb=$(python3 -c "print(f'{$varchar_disk/1024:.0f}')")
+
+    printf "| %-12s | %9s | %12s | %10s | %10s | %10s | %10s |\n" \
+           "Storage" "Write ms" "Rows/s" "Filter ms" "Group ms" "Scan ms" "Disk KB"
+    printf "|%s|%s|%s|%s|%s|%s|%s|\n" \
+           "--------------" "-----------" "--------------" "------------" "------------" "------------" "------------"
+    printf "| %-12s | %9d | %12s | %10d | %10d | %10d | %10s |\n" \
+           "RawDuck" "$rawduck_write" "$rw_rps" \
+           "$rawduck_read_filter" "$rawduck_read_group" "$rawduck_read_scan" "$rd_kb"
+    printf "| %-12s | %9d | %12s | %10d | %10d | %10d | %10s |\n" \
+           "JSON col" "$json_write" "$jw_rps" \
+           "$json_read_filter" "$json_read_group" "$json_read_scan" "$jd_kb"
+    printf "| %-12s | %9d | %12s | %10d | %10d | %10d | %10s |\n" \
+           "VARCHAR col" "$varchar_write" "$vw_rps" \
+           "$varchar_read_filter" "$varchar_read_group" "$varchar_read_scan" "$vd_kb"
+
+    echo ""
+
+    local json_write_pct varchar_write_pct
+    json_write_pct=$(python3 -c "print(f'{($rawduck_write - $json_write) / max($json_write, 1) * 100:+.1f}%')")
+    varchar_write_pct=$(python3 -c "print(f'{($rawduck_write - $varchar_write) / max($varchar_write, 1) * 100:+.1f}%')")
+
+    echo "Write overhead vs opaque:"
+    echo "  RawDuck vs JSON:    $json_write_pct"
+    echo "  RawDuck vs VARCHAR: $varchar_write_pct"
+    echo ""
+
+    if (( rawduck_read_filter > 0 && json_read_filter > 0 )); then
+        local filter_speedup group_speedup scan_speedup
+        filter_speedup=$(python3 -c "print(f'{$json_read_filter / max($rawduck_read_filter, 1):.1f}x')")
+        group_speedup=$(python3 -c "print(f'{$json_read_group / max($rawduck_read_group, 1):.1f}x')")
+        scan_speedup=$(python3 -c "print(f'{$json_read_scan / max($rawduck_read_scan, 1):.1f}x')")
+        echo "Read speedup (RawDuck vs JSON ->> extraction):"
+        echo "  Filter:  ${filter_speedup} faster"
+        echo "  Group:   ${group_speedup} faster"
+        echo "  Scan:    ${scan_speedup} faster"
+    fi
+}
+
+echo "# RawDuck vs Opaque Storage Comparison"
+echo "# $(date -Iseconds)"
+echo "# Rounds: $ROUNDS (best of N)"
+echo "# DuckDB: $DUCKDB"
+
+run_benchmark "100k rows, 6 cols" "$NDJSON_100K" 100000
+run_benchmark "500k rows, 6 cols" "$NDJSON_500K" 500000

--- a/agent_planning/bench/gen_otlp.py
+++ b/agent_planning/bench/gen_otlp.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Generate OTLP/JSON export envelopes for RawDuck benchmark (from BENCHMARK.md)."""
+import json
+import os
+import random
+import sys
+
+random.seed(11)
+SVC = ["checkout", "cart", "payments", "search", "auth", "inventory", "shipping", "frontend"]
+RT = ["/api/v1/orders", "/api/v1/cart", "/api/v1/pay", "/api/v1/search", "/login", "/health"]
+
+
+def kv(k, v):
+    if isinstance(v, bool):
+        return {"key": k, "value": {"boolValue": v}}
+    if isinstance(v, int):
+        return {"key": k, "value": {"intValue": str(v)}}
+    if isinstance(v, float):
+        return {"key": k, "value": {"doubleValue": v}}
+    return {"key": k, "value": {"stringValue": str(v)}}
+
+
+def res(s):
+    return {
+        "attributes": [
+            kv("service.name", s),
+            kv("deployment.environment", "production"),
+            kv("cloud.region", "us-east-1"),
+            kv("host.name", "pod-%d" % random.randint(1, 400)),
+        ]
+    }
+
+
+def span(ts):
+    st = random.choice([200, 200, 200, 201, 400, 404, 500])
+    d = random.randint(2 * 10**5, 8 * 10**8)
+    return {
+        "traceId": os.urandom(16).hex(),
+        "spanId": os.urandom(8).hex(),
+        "name": random.choice(RT),
+        "kind": random.randint(1, 5),
+        "startTimeUnixNano": str(ts),
+        "endTimeUnixNano": str(ts + d),
+        "attributes": [
+            kv("http.method", random.choice(["GET", "POST", "PUT", "DELETE"])),
+            kv("http.route", random.choice(RT)),
+            kv("http.status_code", st),
+            kv("retry", random.choice([True, False])),
+        ],
+        "status": {"code": 2 if st >= 500 else 1},
+    }
+
+
+def log_rec(ts):
+    return {
+        "timeUnixNano": str(ts),
+        "severityNumber": random.choice([9, 13, 17]),
+        "severityText": random.choice(["INFO", "WARN", "ERROR"]),
+        "body": {"stringValue": random.choice(["ok", "timeout", "retry", "fail"])},
+        "attributes": [
+            kv("service.name", random.choice(SVC)),
+            kv("http.status_code", random.choice([200, 404, 500])),
+        ],
+    }
+
+
+def metric(ts):
+    return {
+        "name": random.choice(["cpu.util", "mem.used", "req.latency"]),
+        "sum": {
+            "dataPoints": [
+                {
+                    "timeUnixNano": str(ts),
+                    "asDouble": random.random() * 100,
+                    "attributes": [kv("service.name", random.choice(SVC))],
+                }
+            ]
+        },
+    }
+
+
+def gen(name, total, per, rec, wrap, out_dir):
+    ts = 1_700_000_000_000_000_000
+    w = 0
+    path = os.path.join(out_dir, name + ".ndjson")
+    with open(path, "w") as f:
+        while w < total:
+            n = min(per, total - w)
+            f.write(
+                json.dumps(wrap(random.choice(SVC), [rec(ts + (w + j) * 1000) for j in range(n)]))
+                + "\n"
+            )
+            w += n
+    size_mb = os.path.getsize(path) / (1024 * 1024)
+    print(f"Wrote {path}: {total} records, {size_mb:.1f} MB")
+
+
+def main():
+    n = int(sys.argv[1]) if len(sys.argv) > 1 else 100_000
+    out_dir = sys.argv[2] if len(sys.argv) > 2 else "."
+    gen(
+        "traces",
+        n,
+        80,
+        span,
+        lambda s, r: {"resourceSpans": [{"resource": res(s), "scopeSpans": [{"spans": r}]}]},
+        out_dir,
+    )
+    gen(
+        "logs",
+        n,
+        100,
+        log_rec,
+        lambda s, r: {
+            "resourceLogs": [{"resource": res(s), "scopeLogs": [{"logRecords": r}]}]
+        },
+        out_dir,
+    )
+    gen(
+        "metrics",
+        n,
+        100,
+        metric,
+        lambda s, r: {
+            "resourceMetrics": [{"resource": res(s), "scopeMetrics": [{"metrics": r}]}]
+        },
+        out_dir,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/agent_planning/bench/run_write_matrix.sh
+++ b/agent_planning/bench/run_write_matrix.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Write-path benchmark matrix for RawDuck native ingest.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+DUCKDB="${DUCKDB:-$ROOT/build/release/duckdb}"
+BENCH_DIR="$(cd "$(dirname "$0")" && pwd)"
+DATA_DIR="$BENCH_DIR/data"
+OUT="$BENCH_DIR/write_matrix_results.txt"
+
+if [[ ! -x "$DUCKDB" ]]; then
+  echo "Build first: cd $ROOT && GEN=ninja make release" >&2
+  exit 1
+fi
+
+mkdir -p "$DATA_DIR"
+python3 "$BENCH_DIR/gen_otlp.py" 100000 "$DATA_DIR" >/dev/null 2>&1 || true
+
+measure_ingest_seconds() {
+  local db=$1
+  rm -f "$db"
+  { time -p "$DUCKDB" "$db" <<SQL >/dev/null
+CALL raw_ingest_file('traces', '$DATA_DIR/traces.ndjson', transform := 'otlp-traces');
+SQL
+  } 2>&1 | awk '/^real/{print $2; exit}'
+}
+
+{
+  echo "# RawDuck write matrix $(date -Iseconds)"
+  echo "duckdb=$DUCKDB"
+  echo
+
+  echo "## INSERT ingest narrow (500k rows)"
+  rm -f "$BENCH_DIR/insert_bench.db" "$BENCH_DIR/insert_bench.db.wal"
+  "$DUCKDB" "$BENCH_DIR/insert_bench.db" <<'SQL'
+.timer on
+ATTACH 'rawduck:insert_bench.db' AS raw;
+INSERT INTO raw.ingest.narrow SELECT '{"a":' || range || '}' FROM range(500000);
+SELECT count(*) FROM raw.narrow;
+SQL
+
+  echo
+  echo "## raw_ingest_file OTLP traces (best of 3 runs, default settings)"
+  best=999
+  for run in 1 2 3; do
+    t=$(measure_ingest_seconds "$BENCH_DIR/file_bench.db")
+    echo "  run $run: ${t}s"
+    best=$(python3 -c "print(min(float('$t'), float('$best')))")
+  done
+  rps=$(python3 -c "print(int(round(100000/float('$best'))))")
+  echo "  best: ${best}s (~${rps} rows/s)"
+  "$DUCKDB" "$BENCH_DIR/file_bench.db" <<SQL
+.timer on
+CALL raw_ingest_file('traces', '$DATA_DIR/traces.ndjson', transform := 'otlp-traces');
+SELECT count(*) FROM traces;
+SQL
+
+  echo
+  echo "## raw_ingest_file OTLP (overlap_flush=on, pool_min_rows=512)"
+  rm -f "$BENCH_DIR/file_overlap.db"
+  "$DUCKDB" "$BENCH_DIR/file_overlap.db" <<SQL
+.timer on
+SET rawduck_overlap_flush = true;
+SET rawduck_pool_min_rows = 512;
+CALL raw_ingest_file('traces', '$DATA_DIR/traces.ndjson', transform := 'otlp-traces');
+SELECT count(*) FROM traces;
+SQL
+
+  echo
+  echo "## raw_ingest_file OTLP (overlap_flush_auto, pool_min_rows=4096)"
+  rm -f "$BENCH_DIR/file_auto.db"
+  "$DUCKDB" "$BENCH_DIR/file_auto.db" <<SQL
+.timer on
+SET rawduck_overlap_flush_auto = true;
+SET rawduck_pool_min_rows = 4096;
+CALL raw_ingest_file('traces', '$DATA_DIR/traces.ndjson', transform := 'otlp-traces');
+SELECT count(*) FROM traces;
+SQL
+
+} | tee "$OUT"
+
+echo "Results written to $OUT"

--- a/scripts/ab_bench_lib.sh
+++ b/scripts/ab_bench_lib.sh
@@ -1,0 +1,154 @@
+# Shared A/B benchmark helpers for run_vs_release*.sh
+# shellcheck shell=bash
+
+ab_detect_archive() {
+    local version=$1
+    local os arch
+    os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+    arch="$(uname -m)"
+    case "$os-$arch" in
+        linux-x86_64|linux-amd64) echo "rawduck-linux-amd64-${version}.tar.gz" ;;
+        linux-aarch64|linux-arm64) echo "rawduck-linux-arm64-${version}.tar.gz" ;;
+        darwin-arm64) echo "rawduck-macos-arm64-${version}.tar.gz" ;;
+        darwin-x86_64) echo "rawduck-macos-amd64-${version}.tar.gz" ;;
+        *) echo "Unsupported platform: $os $arch" >&2; return 1 ;;
+    esac
+}
+
+ab_install_release() {
+    local cache=$1 version=$2
+    local archive dest dir url
+    archive="$(ab_detect_archive "$version")"
+    dest="$cache/$archive"
+    url="https://github.com/quackscience/rawduck/releases/download/${version}/${archive}"
+
+    if [[ -x "$cache/bin/rawduck" ]]; then
+        return 0
+    fi
+
+    echo "Downloading RawDuck ${version} (${archive})..."
+    curl -fsSL "$url" -o "$dest"
+    echo "Extracting..."
+    tar -xzf "$dest" -C "$cache"
+
+    dir="$(find "$cache" -maxdepth 1 -type d -name 'rawduck-*' | head -1)"
+    if [[ -z "$dir" || ! -x "$dir/rawduck" ]]; then
+        echo "Release layout unexpected under $cache" >&2
+        return 1
+    fi
+
+    mkdir -p "$cache/bin/extension/rawduck"
+    cp "$dir/duckdb" "$cache/bin/duckdb"
+    cp "$dir/rawduck" "$cache/bin/rawduck"
+    cp "$dir/extension/rawduck/rawduck.duckdb_extension" "$cache/bin/extension/rawduck/"
+    chmod +x "$cache/bin/duckdb" "$cache/bin/rawduck"
+}
+
+ab_install_local_wrapper() {
+    local cache=$1 local_bin=$2
+    mkdir -p "$cache/bin"
+    cat > "$cache/bin/rawduck_local" <<EOF
+#!/bin/sh
+exec "$local_bin" "\$@"
+EOF
+    chmod +x "$cache/bin/rawduck_local"
+}
+
+ab_file_bytes() {
+    [[ -f "$1" ]] && stat -c '%s' "$1" || echo 0
+}
+
+ab_time_best_of_3() {
+    local cmd=$1
+    local best=999999999 i start end ms
+    for i in 1 2 3; do
+        start=$(date +%s%N)
+        eval "$cmd"
+        end=$(date +%s%N)
+        ms=$(( (end - start) / 1000000 ))
+        (( ms < best )) && best=$ms
+    done
+    echo "$best"
+}
+
+ab_time_once() {
+    local cmd=$1 start end ms
+    start=$(date +%s%N)
+    eval "$cmd"
+    end=$(date +%s%N)
+    echo $(( (end - start) / 1000000 ))
+}
+
+ab_bench_read_ms() {
+    local bin=$1 db=$2 attach=$3 query=$4 best_of=$5
+    local best=999999999 i start end ms sql runs
+    sql="${attach} ${query}"
+    runs=${best_of:-3}
+    for ((i = 1; i <= runs; i++)); do
+        start=$(date +%s%N)
+        if [[ -n "$db" ]]; then
+            "$bin" "$db" -csv -c "$sql" >/dev/null 2>&1
+        else
+            "$bin" -csv -c "$sql" >/dev/null 2>&1
+        fi
+        end=$(date +%s%N)
+        ms=$(( (end - start) / 1000000 ))
+        (( ms < best )) && best=$ms
+    done
+    echo "$best"
+}
+
+ab_read_queries() {
+    READ_QUERIES=(
+        "SELECT action, count(*) FROM raw.events GROUP BY action"
+        "SELECT \"user.name\", count(*) AS n FROM raw.events WHERE action = 'click' GROUP BY 1 ORDER BY n DESC LIMIT 5"
+        "SELECT sum(amount) FROM raw.events WHERE amount > 100"
+        "SELECT count(DISTINCT \"user.plan\") FROM raw.events"
+    )
+}
+
+ab_write_rawduck() {
+    local bin=$1 raw_db=$2 data=$3
+    rm -f "$raw_db" "${raw_db}.wal"
+    "$bin" -c "
+        ATTACH 'rawduck:${raw_db}' AS raw;
+        CALL raw_ingest_file('raw.events', '${data}');
+        CHECKPOINT;
+    " >/dev/null 2>&1
+}
+
+ab_bench_round() {
+    # Usage: ab_bench_round label bin raw_db data rows write_mode
+    # write_mode: once | best3
+    local label=$1 bin=$2 raw_db=$3 data=$4 rows=$5 write_mode=${6:-best3}
+    local attach="ATTACH 'rawduck:${raw_db}' AS raw;"
+    local write_ms read_sum read_n q ms read_avg disk rows_out cols
+
+    ab_read_queries
+
+    if [[ "$write_mode" == "once" ]]; then
+        write_ms=$(ab_time_once "ab_write_rawduck '$bin' '$raw_db' '$data'")
+    else
+        write_ms=$(ab_time_best_of_3 "ab_write_rawduck '$bin' '$raw_db' '$data'")
+    fi
+
+    read_sum=0
+    read_n=0
+    for q in "${READ_QUERIES[@]}"; do
+        ms=$(ab_bench_read_ms "$bin" "" "$attach" "$q" 3)
+        read_sum=$((read_sum + ms))
+        read_n=$((read_n + 1))
+    done
+    read_avg=$(awk "BEGIN {printf \"%.1f\", $read_sum / $read_n}")
+
+    disk=$(ab_file_bytes "$raw_db")
+    rows_out=$("$bin" -csv -c "${attach} SELECT count(*) FROM raw.events;" 2>/dev/null | tail -1)
+    cols=$("$bin" -csv -c "${attach} SELECT count(*) FROM information_schema.columns WHERE table_name='events';" 2>/dev/null | tail -1)
+
+    if [[ "$rows_out" != "$rows" ]]; then
+        echo "FAIL: $label row count $rows_out (expected $rows)" >&2
+        return 1
+    fi
+
+    echo "${write_ms},${read_avg},${disk},${cols}"
+}

--- a/scripts/ci_benchmark_gate.sh
+++ b/scripts/ci_benchmark_gate.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# CI gate: run multi-round A/B vs release and fail if local write regresses too much.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+MAX_PCT="${WRITE_REGRESSION_MAX_PCT:-10}"
+ROUNDS="${ROUNDS:-3}"
+
+if [[ ! -x "$ROOT/build/release/duckdb" ]]; then
+  echo "Missing release build. Run: GEN=ninja make release" >&2
+  exit 1
+fi
+
+export ROUNDS
+"$ROOT/scripts/run_vs_release_stats.sh" 50000
+
+python3 - "$ROOT/agent_planning/bench/vs_release/ab_stats_rounds.csv" "$MAX_PCT" <<'PY'
+import csv
+import sys
+from statistics import median
+
+csv_path, max_pct = sys.argv[1], float(sys.argv[2])
+by_round = {}
+with open(csv_path, newline="") as f:
+    for row in csv.DictReader(f):
+        rd = int(row["round"])
+        by_round.setdefault(rd, {})[row["build"]] = float(row["write_ms"])
+
+deltas = []
+for rd in sorted(by_round):
+    rel = by_round[rd]["release"]
+    loc = by_round[rd]["local"]
+    deltas.append((loc - rel) / rel * 100.0)
+
+med = median(deltas)
+wins = sum(1 for d in deltas if d < 0)
+print(f"Write delta per round: {[f'{d:+.1f}%' for d in deltas]}")
+print(f"Median write delta (local vs release): {med:+.1f}%")
+print(f"Local faster in {wins}/{len(deltas)} rounds")
+print(f"Threshold: local may not be more than {max_pct:.0f}% slower (median)")
+
+if med > max_pct:
+    print(f"FAIL: median write regression {med:+.1f}% exceeds +{max_pct:.0f}%")
+    sys.exit(1)
+
+print("PASS: write benchmark within threshold")
+PY

--- a/scripts/gen_compare_data.py
+++ b/scripts/gen_compare_data.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Generate NDJSON for the storage comparison / A/B benchmark."""
+import json
+import random
+import sys
+from pathlib import Path
+
+OUT = Path(sys.argv[2]) if len(sys.argv) > 2 else Path(__file__).resolve().parent.parent / "agent_planning" / "bench" / "data" / "compare_events.ndjson"
+ROWS = int(sys.argv[1]) if len(sys.argv) > 1 else 50000
+
+random.seed(42)
+actions = ["click", "view", "purchase", "login", "logout"]
+plans = ["basic", "pro", "enterprise"]
+
+OUT.parent.mkdir(parents=True, exist_ok=True)
+with open(OUT, "w") as f:
+    for i in range(ROWS):
+        obj = {
+            "id": i,
+            "action": random.choice(actions),
+            "ts": "2024-01-15T10:30:00",
+            "user": {
+                "name": f"user_{i % 500}",
+                "plan": random.choice(plans),
+            },
+            "amount": round(random.uniform(1, 500), 2),
+        }
+        f.write(json.dumps(obj) + "\n")
+
+print(f"Wrote {ROWS} rows to {OUT}")

--- a/scripts/run_vs_release.sh
+++ b/scripts/run_vs_release.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# A/B benchmark: local build vs official RawDuck release (default v0.0.2).
+# Same methodology as https://github.com/adubovikov/rawjsonduck-tests test_compare_storage.sh:
+# best of 3 for write/read, on-disk size after CHECKPOINT.
+#
+# Usage:
+#   ./scripts/run_vs_release.sh              # 50,000 rows
+#   ./scripts/run_vs_release.sh 100000       # custom row count
+#   RELEASE_VERSION=v0.0.3 ./scripts/run_vs_release.sh
+#
+# Requires: curl, python3, bash, a release build (GEN=ninja make release).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ROWS="${1:-50000}"
+RELEASE_VERSION="${RELEASE_VERSION:-v0.0.2}"
+CACHE="$ROOT/agent_planning/bench/.cache/release"
+DATA="$ROOT/agent_planning/bench/data/compare_events.ndjson"
+OUT_DIR="$ROOT/agent_planning/bench/vs_release"
+RESULTS="$OUT_DIR/ab_results.txt"
+LOCAL_BIN="$ROOT/build/release/duckdb"
+
+mkdir -p "$CACHE" "$OUT_DIR"
+
+detect_archive() {
+    local os arch
+    os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+    arch="$(uname -m)"
+    case "$os-$arch" in
+        linux-x86_64|linux-amd64) echo "rawduck-linux-amd64-${RELEASE_VERSION}.tar.gz" ;;
+        linux-aarch64|linux-arm64) echo "rawduck-linux-arm64-${RELEASE_VERSION}.tar.gz" ;;
+        darwin-arm64) echo "rawduck-macos-arm64-${RELEASE_VERSION}.tar.gz" ;;
+        darwin-x86_64) echo "rawduck-macos-amd64-${RELEASE_VERSION}.tar.gz" ;;
+        *) echo "Unsupported platform: $os $arch" >&2; exit 1 ;;
+    esac
+}
+
+install_release() {
+    local archive dest dir url
+    archive="$(detect_archive)"
+    dest="$CACHE/$archive"
+    url="https://github.com/quackscience/rawduck/releases/download/${RELEASE_VERSION}/${archive}"
+
+    if [[ -x "$CACHE/bin/rawduck" ]]; then
+        return 0
+    fi
+
+    echo "Downloading RawDuck ${RELEASE_VERSION} (${archive})..."
+    curl -fsSL "$url" -o "$dest"
+    echo "Extracting..."
+    tar -xzf "$dest" -C "$CACHE"
+
+    # Tarballs unpack to rawduck-linux-amd64/ (or arm64), not *-v0.0.2/
+    dir="$(find "$CACHE" -maxdepth 1 -type d -name 'rawduck-*' | head -1)"
+    if [[ -z "$dir" || ! -x "$dir/rawduck" ]]; then
+        echo "Release layout unexpected under $CACHE" >&2
+        exit 1
+    fi
+
+    mkdir -p "$CACHE/bin/extension/rawduck"
+    cp "$dir/duckdb" "$CACHE/bin/duckdb"
+    cp "$dir/rawduck" "$CACHE/bin/rawduck"
+    cp "$dir/extension/rawduck/rawduck.duckdb_extension" "$CACHE/bin/extension/rawduck/"
+    chmod +x "$CACHE/bin/duckdb" "$CACHE/bin/rawduck"
+    echo "Release binary: $CACHE/bin/rawduck"
+}
+
+install_local_wrapper() {
+    mkdir -p "$CACHE/bin"
+    cat > "$CACHE/bin/rawduck_local" <<EOF
+#!/bin/sh
+exec "$LOCAL_BIN" "\$@"
+EOF
+    chmod +x "$CACHE/bin/rawduck_local"
+}
+
+require_local_build() {
+    if [[ ! -x "$LOCAL_BIN" ]]; then
+        echo "Local build missing. Run: cd $ROOT && GEN=ninja make release" >&2
+        exit 1
+    fi
+}
+
+file_bytes() {
+    [[ -f "$1" ]] && stat -c '%s' "$1" || echo 0
+}
+
+time_best_of_3() {
+    local cmd=$1
+    local best=999999999 i start end ms
+    for i in 1 2 3; do
+        start=$(date +%s%N)
+        eval "$cmd"
+        end=$(date +%s%N)
+        ms=$(( (end - start) / 1000000 ))
+        (( ms < best )) && best=$ms
+    done
+    echo "$best"
+}
+
+bench_read_ms() {
+    local bin=$1 db=$2 attach=$3 query=$4
+    local best=999999999 i start end ms sql
+    sql="${attach} ${query}"
+    for i in 1 2 3; do
+        start=$(date +%s%N)
+        if [[ -n "$db" ]]; then
+            "$bin" "$db" -csv -c "$sql" >/dev/null 2>&1
+        else
+            "$bin" -csv -c "$sql" >/dev/null 2>&1
+        fi
+        end=$(date +%s%N)
+        ms=$(( (end - start) / 1000000 ))
+        (( ms < best )) && best=$ms
+    done
+    echo "$best"
+}
+
+bench_label() {
+    local label=$1 bin=$2
+    local raw_db="$OUT_DIR/${label}_rawduck.db"
+    local attach="ATTACH 'rawduck:${raw_db}' AS raw;"
+    local -a read_queries=(
+        "SELECT action, count(*) FROM raw.events GROUP BY action"
+        "SELECT \"user.name\", count(*) AS n FROM raw.events WHERE action = 'click' GROUP BY 1 ORDER BY n DESC LIMIT 5"
+        "SELECT sum(amount) FROM raw.events WHERE amount > 100"
+        "SELECT count(DISTINCT \"user.plan\") FROM raw.events"
+    )
+
+    echo "" >&2
+    echo "==> Benchmark: $label ($bin)" >&2
+
+    write_rawduck() {
+        rm -f "$raw_db" "${raw_db}.wal"
+        "$bin" -c "
+            ATTACH 'rawduck:${raw_db}' AS raw;
+            CALL raw_ingest_file('raw.events', '${DATA}');
+            CHECKPOINT;
+        " >/dev/null 2>&1
+    }
+
+    local write_ms read_sum read_avg read_n q ms
+    write_ms=$(time_best_of_3 write_rawduck)
+    echo "    write (best of 3): ${write_ms} ms" >&2
+
+    read_sum=0
+    read_n=0
+    for q in "${read_queries[@]}"; do
+        ms=$(bench_read_ms "$bin" "" "$attach" "$q")
+        read_sum=$((read_sum + ms))
+        read_n=$((read_n + 1))
+    done
+    read_avg=$(awk "BEGIN {printf \"%.1f\", $read_sum / $read_n}")
+
+    local disk rows cols
+    disk=$(file_bytes "$raw_db")
+    rows=$("$bin" -csv -c "${attach} SELECT count(*) FROM raw.events;" 2>/dev/null | tail -1)
+    cols=$("$bin" -csv -c "${attach} SELECT count(*) FROM information_schema.columns WHERE table_name='events';" 2>/dev/null | tail -1)
+
+    if [[ "$rows" != "$ROWS" ]]; then
+        echo "FAIL: $label row count $rows (expected $ROWS)" >&2
+        exit 1
+    fi
+
+    echo "    read avg (best of 3 × ${read_n} queries): ${read_avg} ms" >&2
+    echo "    disk: ${disk} bytes | cols: ${cols}" >&2
+
+    echo "${label},${write_ms},${read_avg},${disk},${rows},${cols}"
+}
+
+require_local_build
+install_release
+install_local_wrapper
+python3 "$ROOT/scripts/gen_compare_data.py" "$ROWS" "$DATA" >/dev/null
+
+SOURCE_BYTES=$(file_bytes "$DATA")
+SOURCE_MB=$(awk "BEGIN {printf \"%.2f\", $SOURCE_BYTES / 1048576}")
+
+CSV="$OUT_DIR/ab_metrics.csv"
+echo "label,write_ms,read_avg_ms,disk_bytes,rows,cols" >"$CSV"
+
+{
+    echo "# RawDuck A/B: local build vs ${RELEASE_VERSION}"
+    echo "# $(date -Iseconds)"
+    echo "# Rows: $ROWS | NDJSON: ${SOURCE_MB} MB ($SOURCE_BYTES bytes)"
+    echo "# Local: $LOCAL_BIN"
+    echo "# Release: $CACHE/bin/rawduck"
+    echo ""
+} | tee "$RESULTS"
+
+release_line=$(bench_label "release" "$CACHE/bin/rawduck")
+local_line=$(bench_label "local" "$CACHE/bin/rawduck_local")
+
+echo "$release_line" >>"$CSV"
+echo "$local_line" >>"$CSV"
+
+python3 - "$CSV" "$ROWS" "$RELEASE_VERSION" "$RESULTS" <<'PY'
+import csv
+import sys
+from pathlib import Path
+
+csv_path, rows, version, out_path = sys.argv[1:5]
+rows = int(rows)
+with open(csv_path, newline="") as f:
+    data = {r["label"]: r for r in csv.DictReader(f)}
+
+rel = data["release"]
+loc = data["local"]
+
+def f(x):
+    return float(x)
+
+w_rel, w_loc = f(rel["write_ms"]), f(loc["write_ms"])
+r_rel, r_loc = f(rel["read_avg_ms"]), f(loc["read_avg_ms"])
+d_rel, d_loc = int(rel["disk_bytes"]), int(loc["disk_bytes"])
+t_rel = rows / (w_rel / 1000.0)
+t_loc = rows / (w_loc / 1000.0)
+w_delta = (w_loc - w_rel) / w_rel * 100.0
+r_delta = (r_loc - r_rel) / r_rel * 100.0
+
+lines = [
+    "",
+    "Summary — RawDuck only (best of 3, same as rawjsonduck-tests)",
+    "",
+    f"| Build | Write (ms) | Rows/s | Read avg (ms) | Disk (bytes) |",
+    f"|-------|------------|--------|---------------|--------------|",
+    f"| {version} | {w_rel:.0f} | {t_rel:,.0f} | {r_rel:.1f} | {d_rel} |",
+    f"| local | {w_loc:.0f} | {t_loc:,.0f} | {r_loc:.1f} | {d_loc} |",
+    "",
+    f"Write: {w_delta:+.1f}% ({'faster' if w_delta < 0 else 'slower'} local vs release)",
+    f"Read:  {r_delta:+.1f}% ({'faster' if r_delta < 0 else 'slower'} local vs release)",
+    f"Disk:  {d_loc - d_rel:+d} bytes",
+    "",
+]
+text = "\n".join(lines)
+print(text)
+Path(out_path).write_text(Path(out_path).read_text() + text + "\n")
+PY
+
+echo ""
+echo "Results: $RESULTS"
+echo "Metrics CSV: $CSV"

--- a/scripts/run_vs_release_stats.sh
+++ b/scripts/run_vs_release_stats.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# Multi-round A/B with median / p95 to separate real regression from noise.
+#
+# Usage:
+#   ./scripts/run_vs_release_stats.sh              # 5 rounds, 50k rows
+#   ./scripts/run_vs_release_stats.sh 100000       # 50k rows implied: rounds=5
+#   ROUNDS=10 ./scripts/run_vs_release_stats.sh 50000
+#
+# Each round: single cold-db write per build (paired), read avg (best of 3 × 4 queries).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# shellcheck source=scripts/ab_bench_lib.sh
+source "$ROOT/scripts/ab_bench_lib.sh"
+
+ROWS="${1:-50000}"
+ROUNDS="${ROUNDS:-5}"
+RELEASE_VERSION="${RELEASE_VERSION:-v0.0.2}"
+CACHE="$ROOT/agent_planning/bench/.cache/release"
+DATA="$ROOT/agent_planning/bench/data/compare_events.ndjson"
+OUT_DIR="$ROOT/agent_planning/bench/vs_release"
+RESULTS="$OUT_DIR/ab_stats_results.txt"
+CSV="$OUT_DIR/ab_stats_rounds.csv"
+LOCAL_BIN="$ROOT/build/release/duckdb"
+
+mkdir -p "$CACHE" "$OUT_DIR"
+
+if [[ ! -x "$LOCAL_BIN" ]]; then
+    echo "Local build missing. Run: cd $ROOT && GEN=ninja make release" >&2
+    exit 1
+fi
+
+ab_install_release "$CACHE" "$RELEASE_VERSION"
+ab_install_local_wrapper "$CACHE" "$LOCAL_BIN"
+python3 "$ROOT/scripts/gen_compare_data.py" "$ROWS" "$DATA" >/dev/null
+
+SOURCE_BYTES=$(ab_file_bytes "$DATA")
+SOURCE_MB=$(awk "BEGIN {printf \"%.2f\", $SOURCE_BYTES / 1048576}")
+
+echo "round,build,write_ms,read_avg_ms,disk_bytes,cols" >"$CSV"
+
+{
+    echo "# RawDuck A/B stats: local vs ${RELEASE_VERSION}"
+    echo "# $(date -Iseconds)"
+    echo "# Rounds: $ROUNDS | Rows: $ROWS | NDJSON: ${SOURCE_MB} MB"
+    echo "# Method: one cold write per round per build; read = best-of-3 avg over 4 queries"
+    echo ""
+} | tee "$RESULTS"
+
+round=1
+while (( round <= ROUNDS )); do
+    echo "== Round $round / $ROUNDS ==" >&2
+
+    rel_db="$OUT_DIR/stats_r${round}_release.db"
+    loc_db="$OUT_DIR/stats_r${round}_local.db"
+
+    rel=$(ab_bench_round "release" "$CACHE/bin/rawduck" "$rel_db" "$DATA" "$ROWS" once)
+    loc=$(ab_bench_round "local" "$CACHE/bin/rawduck_local" "$loc_db" "$DATA" "$ROWS" once)
+
+    IFS=',' read -r rel_w rel_r rel_d rel_c <<< "$rel"
+    IFS=',' read -r loc_w loc_r loc_d loc_c <<< "$loc"
+
+    echo "  release: write=${rel_w}ms read_avg=${rel_r}ms disk=${rel_d}" >&2
+    echo "  local:   write=${loc_w}ms read_avg=${loc_r}ms disk=${loc_d}" >&2
+    w_delta=$(awk -v a="$loc_w" -v b="$rel_w" 'BEGIN{printf "%+.1f", (a-b)/b*100}')
+    echo "  write delta: ${w_delta}% (local vs release)" >&2
+
+    echo "${round},release,${rel}" >>"$CSV"
+    echo "${round},local,${loc}" >>"$CSV"
+    round=$((round + 1))
+done
+
+python3 - "$CSV" "$ROWS" "$RELEASE_VERSION" "$ROUNDS" "$RESULTS" <<'PY'
+import csv
+import math
+import sys
+from pathlib import Path
+from statistics import median
+
+csv_path, rows, version, rounds, out_path = sys.argv[1:6]
+rows = int(rows)
+rounds = int(rounds)
+
+by_round = {}
+with open(csv_path, newline="") as f:
+    for r in csv.DictReader(f):
+        rd = int(r["round"])
+        by_round.setdefault(rd, {})[r["build"]] = {
+            "write": float(r["write_ms"]),
+            "read": float(r["read_avg_ms"]),
+            "disk": int(r["disk_bytes"]),
+        }
+
+write_deltas = []
+read_deltas = []
+rel_writes, loc_writes = [], []
+rel_reads, loc_reads = [], []
+
+for rd in sorted(by_round):
+    rel = by_round[rd]["release"]
+    loc = by_round[rd]["local"]
+    rel_writes.append(rel["write"])
+    loc_writes.append(loc["write"])
+    rel_reads.append(rel["read"])
+    loc_reads.append(loc["read"])
+    write_deltas.append((loc["write"] - rel["write"]) / rel["write"] * 100.0)
+    read_deltas.append((loc["read"] - rel["read"]) / rel["read"] * 100.0)
+
+
+def percentile(vals, p):
+    if not vals:
+        return float("nan")
+    s = sorted(vals)
+    k = (len(s) - 1) * p / 100.0
+    f = math.floor(k)
+    c = math.ceil(k)
+    if f == c:
+        return s[int(k)]
+    return s[f] * (c - k) + s[c] * (k - f)
+
+
+def stat_block(name, rel_vals, loc_vals, deltas):
+    med_rel = median(rel_vals)
+    med_loc = median(loc_vals)
+    med_delta = median(deltas)
+    p95_delta = percentile(deltas, 95)
+    wins = sum(1 for d in deltas if d < 0)
+    return {
+        "name": name,
+        "rel_med": med_rel,
+        "loc_med": med_loc,
+        "rel_min": min(rel_vals),
+        "rel_max": max(rel_vals),
+        "loc_min": min(loc_vals),
+        "loc_max": max(loc_vals),
+        "delta_med": med_delta,
+        "delta_p95": p95_delta,
+        "wins": wins,
+        "rounds": len(deltas),
+    }
+
+
+w = stat_block("write", rel_writes, loc_writes, write_deltas)
+r = stat_block("read", rel_reads, loc_reads, read_deltas)
+
+def rows_per_s(ms):
+    return rows / (ms / 1000.0)
+
+
+def verdict(delta_med, metric):
+    if abs(delta_med) < 3.0:
+        return f"INCONCLUSIVE on {metric} (median delta {delta_med:+.1f}% — within ~3% noise band)"
+    if delta_med < 0:
+        return f"LOCAL FASTER on {metric} (median {delta_med:+.1f}%)"
+    return f"LOCAL SLOWER on {metric} (median {delta_med:+.1f}% — possible regression)"
+
+
+lines = [
+    "",
+    f"Aggregated over {rounds} paired rounds",
+    "",
+    "Per-round write (ms):",
+    f"  release: {rel_writes}",
+    f"  local:   {loc_writes}",
+    f"  delta %: {[f'{d:+.1f}' for d in write_deltas]}",
+    "",
+    "Per-round read avg (ms):",
+    f"  release: {rel_reads}",
+    f"  local:   {loc_reads}",
+    f"  delta %: {[f'{d:+.1f}' for d in read_deltas]}",
+    "",
+    "Write statistics:",
+    f"  release median: {w['rel_med']:.0f} ms  (min {w['rel_min']:.0f}, max {w['rel_max']:.0f})",
+    f"  local   median: {w['loc_med']:.0f} ms  (min {w['loc_min']:.0f}, max {w['loc_max']:.0f})",
+    f"  local vs release median: {w['delta_med']:+.1f}%",
+    f"  local vs release p95:    {w['delta_p95']:+.1f}%",
+    f"  local wins (faster):     {w['wins']}/{w['rounds']} rounds",
+    f"  release throughput med:  {rows_per_s(w['rel_med']):,.0f} rows/s",
+    f"  local   throughput med:  {rows_per_s(w['loc_med']):,.0f} rows/s",
+    "",
+    "Read statistics:",
+    f"  release median: {r['rel_med']:.1f} ms  (min {r['rel_min']:.1f}, max {r['rel_max']:.1f})",
+    f"  local   median: {r['loc_med']:.1f} ms  (min {r['loc_min']:.1f}, max {r['loc_max']:.1f})",
+    f"  local vs release median: {r['delta_med']:+.1f}%",
+    f"  local vs release p95:    {r['delta_p95']:+.1f}%",
+    f"  local wins (faster):     {r['wins']}/{r['rounds']} rounds",
+    "",
+    "Verdict:",
+    f"  {verdict(w['delta_med'], 'write')}",
+    f"  {verdict(r['delta_med'], 'read')}",
+    "",
+]
+text = "\n".join(lines)
+print(text)
+Path(out_path).write_text(Path(out_path).read_text() + text + "\n")
+PY
+
+echo ""
+echo "Results: $RESULTS"
+echo "Round CSV: $CSV"

--- a/src/include/raw_functions.hpp
+++ b/src/include/raw_functions.hpp
@@ -11,6 +11,7 @@ struct StorageExtensionInfo;
 class TransactionManager;
 struct RawParseOptions;
 struct RawParsedPayload;
+struct RawCachedSchema;
 
 TableFunction GetRawRecordsFunction();
 TableFunction GetRawIngestFunction();
@@ -57,6 +58,9 @@ public:
 	virtual void Finish() = 0;
 	virtual idx_t Rows() const = 0;
 	virtual RawIngestStats GetStats() const = 0;
+	// for schema cache lookups by parser threads
+	virtual string GetSchemaCacheKey() const = 0;
+	virtual shared_ptr<RawCachedSchema> LookupCachedSchema(uint64_t shape) = 0;
 };
 unique_ptr<RawStreamIngestor> RawCreateStreamIngestor(ClientContext &context, const string &target,
                                                       RawParseOptions options);

--- a/src/include/raw_json.hpp
+++ b/src/include/raw_json.hpp
@@ -3,6 +3,8 @@
 #include "duckdb.hpp"
 #include "yyjson.hpp"
 
+#include <cstring>
+
 namespace duckdb {
 
 //===--------------------------------------------------------------------===//
@@ -27,15 +29,31 @@ enum class RawNodeClass : uint8_t {
 	JSON       // structural conflict or unflattenable value: stored as JSON text
 };
 
+static constexpr idx_t RAW_NODE_NO_COLUMN = DConstants::INVALID_INDEX;
+
 struct RawNode {
 	RawNodeClass node_class = RawNodeClass::UNSET;
 	RawScalarKind scalar = RawScalarKind::UNSET;
+	// set by FlattenSchema: dense column index for leaf nodes, INVALID for
+	// intermediate objects — eliminates hash lookups in the extraction hot path
+	idx_t column_idx = RAW_NODE_NO_COLUMN;
 	// object children in first-seen order, so inferred column order is stable
 	vector<pair<string, unique_ptr<RawNode>>> children;
 	unordered_map<string, idx_t> child_lookup;
 	unique_ptr<RawNode> element;
 
 	RawNode &GetOrCreateChild(const string &key);
+
+	// zero-alloc child lookup by raw pointer+length (extraction hot path)
+	idx_t FindChild(const char *key, size_t len) const {
+		for (idx_t i = 0; i < children.size(); i++) {
+			auto &name = children[i].first;
+			if (name.size() == len && memcmp(name.data(), key, len) == 0) {
+				return i;
+			}
+		}
+		return DConstants::INVALID_INDEX;
+	}
 };
 
 // A flattened output column: `name` is the dotted path, `path` the segments to
@@ -81,15 +99,32 @@ struct RawPayload {
 	void Explode(const vector<string> &path);
 };
 
+// Immutable schema snapshot for reuse across batches with the same shape.
+// Shared (via shared_ptr) between RawSchemaCache and parser threads.
+struct RawCachedSchema {
+	shared_ptr<RawNode> root;
+	vector<RawColumn> columns;
+};
+
 // A fully processed payload: parsed rows plus the inferred flattened schema.
 // Parsed exactly once and shared by inference and extraction.
 struct RawParsedPayload {
 	RawPayload payload;
 	unique_ptr<RawNode> root;
+	// when using a cached schema, root_shared keeps it alive and root is unused
+	shared_ptr<RawNode> root_shared;
 	vector<RawColumn> columns;
+
+	const RawNode &SchemaRoot() const {
+		return root_shared ? *root_shared : *root;
+	}
 
 	static shared_ptr<RawParsedPayload> Process(const string &payload_text,
 	                                            const RawParseOptions &options = RawParseOptions());
+	// fast path: skip inference, reuse cached schema
+	static shared_ptr<RawParsedPayload> ProcessWithSchema(const string &payload_text,
+	                                                      const RawParseOptions &options,
+	                                                      const shared_ptr<RawCachedSchema> &cached);
 };
 
 // Incremental payload assembly (zero-copy INSERT sink): parse documents one
@@ -97,6 +132,9 @@ struct RawParsedPayload {
 // inference + flattening) once per batch.
 void RawPayloadAddDocument(RawParsedPayload &payload, const char *data, idx_t size, bool ignore_errors = false);
 void RawPayloadFinalize(RawParsedPayload &payload, const RawParseOptions &options = RawParseOptions());
+
+// FNV-1a hash over column names + type ids; used by the schema shape cache
+uint64_t HashPayloadShape(const vector<RawColumn> &columns);
 
 // Built-in ingest-time transforms (name -> dotted explode path); users can
 // register additional ones via raw_transform_define().
@@ -110,13 +148,14 @@ RawScalarKind SniffScalarKind(duckdb_yyjson::yyjson_val *val);
 void MergeValue(RawNode &node, duckdb_yyjson::yyjson_val *val);
 
 LogicalType NodeToType(const RawNode &node);
-vector<RawColumn> FlattenSchema(const RawNode &root, bool scalar_rows);
+vector<RawColumn> FlattenSchema(RawNode &root, bool scalar_rows);
 
 bool IsRawJSONType(const LogicalType &type);
 
 // Vectorized extraction. Rows are typically sparse compared to the unified
 // schema, so extraction is row-major: each row's JSON tree is traversed once
 // and values are routed to their column slot via the schema-tree nodes.
+// Uses dense column_idx on RawNode (set by FlattenSchema) instead of hash maps.
 class RawExtractor {
 public:
 	RawExtractor(const RawNode &root, const vector<RawColumn> &columns);
@@ -134,9 +173,9 @@ private:
 	void Traverse(duckdb_yyjson::yyjson_val *val, const RawNode &node, idx_t row_idx);
 
 	const RawNode &root;
-	// schema-tree leaf -> column slot
-	unordered_map<const RawNode *, idx_t> column_of;
 	bool root_is_column = false;
+	idx_t root_column_idx = RAW_NODE_NO_COLUMN;
+	idx_t column_count = 0;
 	vector<vector<duckdb_yyjson::yyjson_val *>> values;
 };
 

--- a/src/include/raw_json.hpp
+++ b/src/include/raw_json.hpp
@@ -122,8 +122,7 @@ struct RawParsedPayload {
 	static shared_ptr<RawParsedPayload> Process(const string &payload_text,
 	                                            const RawParseOptions &options = RawParseOptions());
 	// fast path: skip inference, reuse cached schema
-	static shared_ptr<RawParsedPayload> ProcessWithSchema(const string &payload_text,
-	                                                      const RawParseOptions &options,
+	static shared_ptr<RawParsedPayload> ProcessWithSchema(const string &payload_text, const RawParseOptions &options,
 	                                                      const shared_ptr<RawCachedSchema> &cached);
 };
 

--- a/src/raw_ingest.cpp
+++ b/src/raw_ingest.cpp
@@ -63,12 +63,28 @@ public:
 		// validity token: the table's DataTable address at absorption time
 		void *storage_token = nullptr;
 		unordered_set<uint64_t> absorbed_shapes;
+		// cached schema trees keyed by shape hash — parser threads can skip
+		// InferSchema+FlattenSchema when a shape has been absorbed
+		unordered_map<uint64_t, shared_ptr<RawCachedSchema>> cached_schemas;
 	};
 	mutex lock;
 	unordered_map<string, Entry> tables;
+
+	shared_ptr<RawCachedSchema> LookupSchema(const string &table_key, uint64_t shape) {
+		lock_guard<mutex> guard(lock);
+		auto entry = tables.find(table_key);
+		if (entry == tables.end()) {
+			return nullptr;
+		}
+		auto schema_it = entry->second.cached_schemas.find(shape);
+		if (schema_it == entry->second.cached_schemas.end()) {
+			return nullptr;
+		}
+		return schema_it->second;
+	}
 };
 
-static uint64_t HashPayloadShape(const vector<RawColumn> &columns) {
+uint64_t HashPayloadShape(const vector<RawColumn> &columns) {
 	uint64_t shape = 0xcbf29ce484222325ULL;
 	for (auto &column : columns) {
 		for (auto c : column.name) {
@@ -467,7 +483,7 @@ private:
 	void AppendBatch(Worker &worker, RawParsedPayload &parsed, DataChunk &chunk, bool allow_flush) {
 		auto &types = worker.local_types;
 		auto &slots = worker.local_slots;
-		RawExtractor extractor(*parsed.root, parsed.columns);
+		RawExtractor extractor(parsed.SchemaRoot(), parsed.columns);
 		auto shape = HashPayloadShape(parsed.columns);
 		vector<idx_t> slot_of;
 		vector<bool> covered;
@@ -613,6 +629,10 @@ public:
 		}
 	}
 
+	string CacheKey() const {
+		return qname.catalog + "." + qname.schema + "." + qname.name;
+	}
+
 	// Schema evolution (serial). Returns true when the append pool owns the batch.
 	bool PrepareForAppend(RawParsedPayload &parsed) {
 		write_settings = RawWriteSettings::Get(context);
@@ -656,8 +676,20 @@ public:
 			if (entry.storage_token != &table->GetStorage()) {
 				entry.storage_token = &table->GetStorage();
 				entry.absorbed_shapes.clear();
+				entry.cached_schemas.clear();
 			}
 			entry.absorbed_shapes.insert(shape);
+			if (entry.cached_schemas.find(shape) == entry.cached_schemas.end()) {
+				auto cached = make_shared_ptr<RawCachedSchema>();
+				if (parsed.root_shared) {
+					cached->root = parsed.root_shared;
+				} else {
+					cached->root = make_shared_ptr<RawNode>(std::move(*parsed.root));
+					parsed.root_shared = cached->root;
+				}
+				cached->columns = parsed.columns;
+				entry.cached_schemas[shape] = std::move(cached);
+			}
 			last_batch_shape_absorbed = true;
 		}
 		if (parsed.payload.rows.empty()) {
@@ -985,7 +1017,7 @@ private:
 
 		DataChunk chunk;
 		chunk.Initialize(Allocator::Get(context), types);
-		RawExtractor extractor(*parsed.root, parsed.columns);
+		RawExtractor extractor(parsed.SchemaRoot(), parsed.columns);
 		auto &storage = table.GetStorage();
 		auto &payload_rows = parsed.payload.rows;
 
@@ -1201,7 +1233,21 @@ namespace {
 class RawStreamIngestorImpl : public RawStreamIngestor {
 public:
 	RawStreamIngestorImpl(ClientContext &context, const string &target, RawParseOptions options)
-	    : parse_options(options), ingestor(context, target, std::move(options)) {
+	    : context_ref(context), parse_options(options), ingestor(context, target, std::move(options)) {
+		auto qname = QualifiedName::Parse(target);
+		if (qname.catalog.empty() && !qname.schema.empty()) {
+			if (DatabaseManager::Get(context).GetDatabase(context, qname.schema)) {
+				qname.catalog = qname.schema;
+				qname.schema = DEFAULT_SCHEMA;
+			}
+		}
+		if (qname.catalog.empty()) {
+			qname.catalog = DatabaseManager::GetDefaultDatabase(context);
+		}
+		if (qname.schema.empty()) {
+			qname.schema = DEFAULT_SCHEMA;
+		}
+		schema_cache_key = qname.catalog + "." + qname.schema + "." + qname.name;
 	}
 	void Ingest(const string &payload) override {
 		ingestor.Ingest(payload);
@@ -1242,8 +1288,22 @@ public:
 		return stats;
 	}
 
+	string GetSchemaCacheKey() const override {
+		return schema_cache_key;
+	}
+	shared_ptr<RawCachedSchema> LookupCachedSchema(uint64_t shape) override {
+		auto &obj_cache = ObjectCache::GetObjectCache(context_ref);
+		auto cache = obj_cache.Get<RawSchemaCache>(RawSchemaCache::ObjectType());
+		if (!cache) {
+			return nullptr;
+		}
+		return cache->LookupSchema(schema_cache_key, shape);
+	}
+
 private:
+	ClientContext &context_ref;
 	RawParseOptions parse_options;
+	string schema_cache_key;
 	string empty_payload;
 	mutex schema_lock;
 	RawIngestor ingestor;
@@ -1546,17 +1606,33 @@ static void RawIngestFileFunction(ClientContext &context, TableFunctionInput &da
 	});
 
 	// parse workers: parsing and inference are pure and scale with cores;
-	// batch order is irrelevant to ingestion
+	// batch order is irrelevant to ingestion.
+	// Schema cache fast path: once the consumer absorbs a shape, parser threads
+	// reuse the cached schema tree, skipping InferSchema+FlattenSchema entirely.
 	auto parser_count = write_settings.PipelineThreadCount();
 	pipeline.active_parsers = parser_count;
+	shared_ptr<RawCachedSchema> pipeline_cached_schema;
+	mutex pipeline_schema_lock;
+	std::atomic<bool> pipeline_schema_ready {false};
 	vector<std::thread> parsers;
 	for (idx_t i = 0; i < parser_count; i++) {
-		parsers.emplace_back([&pipeline, options] {
+		parsers.emplace_back([&pipeline, options, &pipeline_cached_schema, &pipeline_schema_lock,
+		                      &pipeline_schema_ready] {
 			std::exception_ptr parser_error;
 			try {
+				shared_ptr<RawCachedSchema> local_cached;
 				string batch;
 				while (pipeline.PopRaw(batch)) {
-					auto parsed = RawParsedPayload::Process(batch, options);
+					if (!local_cached && pipeline_schema_ready.load(std::memory_order_acquire)) {
+						lock_guard<mutex> guard(pipeline_schema_lock);
+						local_cached = pipeline_cached_schema;
+					}
+					shared_ptr<RawParsedPayload> parsed;
+					if (local_cached) {
+						parsed = RawParsedPayload::ProcessWithSchema(batch, options, local_cached);
+					} else {
+						parsed = RawParsedPayload::Process(batch, options);
+					}
 					pipeline.Push(RawIngestPipeline::Item {std::move(parsed), std::move(batch)});
 				}
 			} catch (...) {
@@ -1601,6 +1677,7 @@ static void RawIngestFileFunction(ClientContext &context, TableFunctionInput &da
 	try {
 		if (consumer_count > 1) {
 			auto stream = RawCreateStreamIngestor(context, bind_data.target, bind_data.options);
+			bool mc_schema_published = pipeline_schema_ready.load(std::memory_order_relaxed);
 			auto consumer_loop = [&] {
 				try {
 					RawIngestPipeline::Item pending_storage;
@@ -1610,7 +1687,17 @@ static void RawIngestFileFunction(ClientContext &context, TableFunctionInput &da
 						batches.fetch_add(1);
 						coalesce_and_ingest(
 						    [&](RawIngestPipeline::Item pending) {
+							    auto pending_shape = HashPayloadShape(pending.parsed->columns);
 							    stream->IngestParsedConcurrent(std::move(pending.parsed));
+							    if (!mc_schema_published) {
+								    auto cached = stream->LookupCachedSchema(pending_shape);
+								    if (cached) {
+									    lock_guard<mutex> guard(pipeline_schema_lock);
+									    pipeline_cached_schema = std::move(cached);
+									    pipeline_schema_ready.store(true, std::memory_order_release);
+									    mc_schema_published = true;
+								    }
+							    }
 						    },
 						    pending_storage, has_pending, std::move(item));
 					}
@@ -1643,12 +1730,28 @@ static void RawIngestFileFunction(ClientContext &context, TableFunctionInput &da
 			RawIngestor ingestor(context, bind_data.target, bind_data.options);
 			RawIngestPipeline::Item pending_storage;
 			bool has_pending = false;
+			bool schema_published = pipeline_schema_ready.load(std::memory_order_relaxed);
+			auto cache_key = ingestor.CacheKey();
 			RawIngestPipeline::Item item;
 			while (pipeline.Pop(item)) {
 				batches_result++;
 				coalesce_and_ingest(
 				    [&](RawIngestPipeline::Item pending) {
+					    auto pending_shape = HashPayloadShape(pending.parsed->columns);
 					    ingestor.IngestParsed(std::move(pending.parsed), pending.payload);
+					    if (!schema_published) {
+						    auto &obj_cache = ObjectCache::GetObjectCache(context);
+						    auto cache = obj_cache.Get<RawSchemaCache>(RawSchemaCache::ObjectType());
+						    if (cache) {
+							    auto cached = cache->LookupSchema(cache_key, pending_shape);
+							    if (cached) {
+								    lock_guard<mutex> guard(pipeline_schema_lock);
+								    pipeline_cached_schema = std::move(cached);
+								    pipeline_schema_ready.store(true, std::memory_order_release);
+								    schema_published = true;
+							    }
+						    }
+					    }
 				    },
 				    pending_storage, has_pending, std::move(item));
 			}

--- a/src/raw_ingest.cpp
+++ b/src/raw_ingest.cpp
@@ -1616,30 +1616,30 @@ static void RawIngestFileFunction(ClientContext &context, TableFunctionInput &da
 	std::atomic<bool> pipeline_schema_ready {false};
 	vector<std::thread> parsers;
 	for (idx_t i = 0; i < parser_count; i++) {
-		parsers.emplace_back([&pipeline, options, &pipeline_cached_schema, &pipeline_schema_lock,
-		                      &pipeline_schema_ready] {
-			std::exception_ptr parser_error;
-			try {
-				shared_ptr<RawCachedSchema> local_cached;
-				string batch;
-				while (pipeline.PopRaw(batch)) {
-					if (!local_cached && pipeline_schema_ready.load(std::memory_order_acquire)) {
-						lock_guard<mutex> guard(pipeline_schema_lock);
-						local_cached = pipeline_cached_schema;
-					}
-					shared_ptr<RawParsedPayload> parsed;
-					if (local_cached) {
-						parsed = RawParsedPayload::ProcessWithSchema(batch, options, local_cached);
-					} else {
-						parsed = RawParsedPayload::Process(batch, options);
-					}
-					pipeline.Push(RawIngestPipeline::Item {std::move(parsed), std::move(batch)});
-				}
-			} catch (...) {
-				parser_error = std::current_exception();
-			}
-			pipeline.ParserDone(parser_error);
-		});
+		parsers.emplace_back(
+		    [&pipeline, options, &pipeline_cached_schema, &pipeline_schema_lock, &pipeline_schema_ready] {
+			    std::exception_ptr parser_error;
+			    try {
+				    shared_ptr<RawCachedSchema> local_cached;
+				    string batch;
+				    while (pipeline.PopRaw(batch)) {
+					    if (!local_cached && pipeline_schema_ready.load(std::memory_order_acquire)) {
+						    lock_guard<mutex> guard(pipeline_schema_lock);
+						    local_cached = pipeline_cached_schema;
+					    }
+					    shared_ptr<RawParsedPayload> parsed;
+					    if (local_cached) {
+						    parsed = RawParsedPayload::ProcessWithSchema(batch, options, local_cached);
+					    } else {
+						    parsed = RawParsedPayload::Process(batch, options);
+					    }
+					    pipeline.Push(RawIngestPipeline::Item {std::move(parsed), std::move(batch)});
+				    }
+			    } catch (...) {
+				    parser_error = std::current_exception();
+			    }
+			    pipeline.ParserDone(parser_error);
+		    });
 	}
 	auto join_all = [&] {
 		reader.join();

--- a/src/raw_json.cpp
+++ b/src/raw_json.cpp
@@ -503,6 +503,7 @@ void RawPayloadFinalize(RawParsedPayload &parsed, const RawParseOptions &options
 		parsed.payload.Explode(options.explode_path);
 	}
 	parsed.root = parsed.payload.InferSchema();
+	// FlattenSchema assigns column_idx on each leaf node
 	parsed.columns = FlattenSchema(*parsed.root, parsed.payload.scalar_rows);
 }
 
@@ -511,6 +512,16 @@ shared_ptr<RawParsedPayload> RawParsedPayload::Process(const string &payload_tex
 	result->payload.Parse(payload_text, options);
 	result->root = result->payload.InferSchema();
 	result->columns = FlattenSchema(*result->root, result->payload.scalar_rows);
+	return result;
+}
+
+shared_ptr<RawParsedPayload> RawParsedPayload::ProcessWithSchema(const string &payload_text,
+                                                                  const RawParseOptions &options,
+                                                                  const shared_ptr<RawCachedSchema> &cached) {
+	auto result = make_shared_ptr<RawParsedPayload>();
+	result->payload.Parse(payload_text, options);
+	result->root_shared = cached->root;
+	result->columns = cached->columns;
 	return result;
 }
 
@@ -662,8 +673,14 @@ static void MergeValueInternal(RawNode &node, yyjson_val *val, idx_t depth) {
 		duckdb_yyjson::yyjson_obj_iter_init(val, &iter);
 		while (auto key = duckdb_yyjson::yyjson_obj_iter_next(&iter)) {
 			auto child_val = duckdb_yyjson::yyjson_obj_iter_get_val(key);
-			auto key_str = string(duckdb_yyjson::yyjson_get_str(key), duckdb_yyjson::yyjson_get_len(key));
-			MergeValueInternal(node.GetOrCreateChild(key_str), child_val, depth + 1);
+			auto key_ptr = duckdb_yyjson::yyjson_get_str(key);
+			auto key_len = duckdb_yyjson::yyjson_get_len(key);
+			auto existing = node.FindChild(key_ptr, key_len);
+			if (existing != DConstants::INVALID_INDEX) {
+				MergeValueInternal(*node.children[existing].second, child_val, depth + 1);
+			} else {
+				MergeValueInternal(node.GetOrCreateChild(string(key_ptr, key_len)), child_val, depth + 1);
+			}
 		}
 		return;
 	}
@@ -747,7 +764,7 @@ LogicalType NodeToType(const RawNode &node) {
 	}
 }
 
-static void FlattenInto(const RawNode &node, const string &prefix, vector<string> &path, idx_t depth,
+static void FlattenInto(RawNode &node, const string &prefix, vector<string> &path, idx_t depth,
                         vector<RawColumn> &result) {
 	for (auto &entry : node.children) {
 		auto &name = entry.first;
@@ -755,20 +772,23 @@ static void FlattenInto(const RawNode &node, const string &prefix, vector<string
 		auto column_name = prefix.empty() ? name : prefix + "." + name;
 		path.push_back(name);
 		if (child.node_class == RawNodeClass::OBJECT && !child.children.empty() && depth < RAW_MAX_FLATTEN_DEPTH) {
+			child.column_idx = RAW_NODE_NO_COLUMN;
 			FlattenInto(child, column_name, path, depth + 1, result);
 		} else {
+			child.column_idx = result.size();
 			result.push_back(RawColumn {column_name, path, NodeToType(child), &child});
 		}
 		path.pop_back();
 	}
 }
 
-vector<RawColumn> FlattenSchema(const RawNode &root, bool scalar_rows) {
+vector<RawColumn> FlattenSchema(RawNode &root, bool scalar_rows) {
 	vector<RawColumn> result;
 	if (scalar_rows || root.node_class != RawNodeClass::OBJECT) {
 		if (root.node_class == RawNodeClass::UNSET) {
 			return result;
 		}
+		root.column_idx = 0;
 		result.push_back(RawColumn {"value", {}, NodeToType(root), &root});
 		return result;
 	}
@@ -780,7 +800,6 @@ vector<RawColumn> FlattenSchema(const RawNode &root, bool scalar_rows) {
 		    "reduce key cardinality",
 		    result.size(), RAW_MAX_COLUMNS);
 	}
-	// flattening can collide (e.g. key "a.b" vs nested a->b): disambiguate
 	case_insensitive_set_t seen;
 	for (auto &column : result) {
 		auto base = column.name;
@@ -821,48 +840,46 @@ bool RawFillSupported(const LogicalType &type) {
 }
 
 RawExtractor::RawExtractor(const RawNode &root_p, const vector<RawColumn> &columns) : root(root_p) {
-	values.resize(columns.size());
-	for (idx_t col = 0; col < columns.size(); col++) {
+	column_count = columns.size();
+	values.resize(column_count);
+	for (idx_t col = 0; col < column_count; col++) {
 		if (columns[col].path.empty()) {
-			// "value" column: the row itself is the value
 			root_is_column = true;
+			root_column_idx = root_p.column_idx;
 		}
-		column_of[columns[col].node] = col;
 	}
 }
 
 void RawExtractor::Reset(idx_t row_count) {
-	for (auto &column_values : values) {
-		column_values.assign(row_count, nullptr);
+	for (idx_t col = 0; col < column_count; col++) {
+		auto &cv = values[col];
+		cv.resize(row_count);
+		memset(cv.data(), 0, row_count * sizeof(duckdb_yyjson::yyjson_val *));
 	}
 }
 
 void RawExtractor::Traverse(yyjson_val *val, const RawNode &node, idx_t row_idx) {
-	auto leaf = column_of.find(&node);
-	if (leaf != column_of.end()) {
-		values[leaf->second][row_idx] = val;
+	if (node.column_idx != RAW_NODE_NO_COLUMN) {
+		values[node.column_idx][row_idx] = val;
 		return;
 	}
 	if (node.node_class != RawNodeClass::OBJECT || !duckdb_yyjson::yyjson_is_obj(val)) {
-		// value at a path that is neither a column nor a flattened object
-		// (e.g. a structural mismatch): nothing to route
 		return;
 	}
 	yyjson_obj_iter iter;
 	duckdb_yyjson::yyjson_obj_iter_init(val, &iter);
 	while (auto key = duckdb_yyjson::yyjson_obj_iter_next(&iter)) {
-		auto entry =
-		    node.child_lookup.find(string(duckdb_yyjson::yyjson_get_str(key), duckdb_yyjson::yyjson_get_len(key)));
-		if (entry == node.child_lookup.end()) {
+		auto child_idx = node.FindChild(duckdb_yyjson::yyjson_get_str(key), duckdb_yyjson::yyjson_get_len(key));
+		if (child_idx == DConstants::INVALID_INDEX) {
 			continue;
 		}
-		Traverse(duckdb_yyjson::yyjson_obj_iter_get_val(key), *node.children[entry->second].second, row_idx);
+		Traverse(duckdb_yyjson::yyjson_obj_iter_get_val(key), *node.children[child_idx].second, row_idx);
 	}
 }
 
 void RawExtractor::AssignRow(yyjson_val *row, idx_t row_idx) {
 	if (root_is_column) {
-		values[column_of.at(&root)][row_idx] = row;
+		values[root_column_idx][row_idx] = row;
 		return;
 	}
 	Traverse(row, root, row_idx);

--- a/src/raw_json.cpp
+++ b/src/raw_json.cpp
@@ -516,8 +516,8 @@ shared_ptr<RawParsedPayload> RawParsedPayload::Process(const string &payload_tex
 }
 
 shared_ptr<RawParsedPayload> RawParsedPayload::ProcessWithSchema(const string &payload_text,
-                                                                  const RawParseOptions &options,
-                                                                  const shared_ptr<RawCachedSchema> &cached) {
+                                                                 const RawParseOptions &options,
+                                                                 const shared_ptr<RawCachedSchema> &cached) {
 	auto result = make_shared_ptr<RawParsedPayload>();
 	result->payload.Parse(payload_text, options);
 	result->root_shared = cached->root;

--- a/src/raw_records.cpp
+++ b/src/raw_records.cpp
@@ -11,7 +11,7 @@ struct RawRecordsBindData : public TableFunctionData {
 
 struct RawRecordsState : public GlobalTableFunctionState {
 	explicit RawRecordsState(const RawRecordsBindData &bind_data)
-	    : extractor(*bind_data.parsed->root, bind_data.parsed->columns) {
+	    : extractor(bind_data.parsed->SchemaRoot(), bind_data.parsed->columns) {
 	}
 
 	idx_t next_row = 0;


### PR DESCRIPTION
## Summary

Skip per-batch schema inference on stable shapes + optimize the extraction hot path:

- **Schema cache**: `RawCachedSchema` in `ObjectCache` keyed by shape hash. Once a shape is absorbed, parser threads in `raw_ingest_file` reuse the cached schema tree — `InferSchema` + `FlattenSchema` are skipped entirely.
- **Dense `column_idx`** on `RawNode` replaces `unordered_map<RawNode*,idx_t>` hash lookup in `RawExtractor::Traverse` with direct indexing.
- **Zero-alloc `FindChild`** (`memcmp` linear scan) replaces `child_lookup.find(string(key,len))` — eliminates one `std::string` allocation per JSON key per row in both extraction and inference (`MergeValueInternal`).
- **`memset` Reset** in `RawExtractor` replaces `vector::assign`.
- CI benchmark gate (`PrValidation.yml`) and A/B comparison scripts.

## Benchmark results

10-round best-of-N, 6 columns (`id` BIGINT, `name` VARCHAR, `score` DOUBLE, `active` BOOL, `created` DATE, `tag` VARCHAR). DuckDB v1.5.3, based on current `main` (includes PR #5).

### RawDuck vs Opaque Storage: 100k rows

| Storage | Write ms | Rows/s | Filter ms | Group ms | Scan ms | Disk KB |
|---|---:|---:|---:|---:|---:|---:|
| RawDuck | 106 | 943,396 | 15 | 16 | 16 | 1,548 |
| JSON col | 85 | 1,176,471 | 31 | 41 | 26 | 2,828 |
| VARCHAR col | 80 | 1,250,000 | 38 | 48 | 36 | 3,084 |

- Write overhead: +25% vs JSON, +33% vs VARCHAR (shredding cost at small scale)
- Read speedup: **2.1x** filter, **2.6x** group by, **1.6x** scan vs JSON
- Disk: **1.8-2.0x** smaller

### RawDuck vs Opaque Storage: 500k rows

| Storage | Write ms | Rows/s | Filter ms | Group ms | Scan ms | Disk KB |
|---|---:|---:|---:|---:|---:|---:|
| RawDuck | 193 | 2,590,674 | 16 | 17 | 14 | 4,876 |
| JSON col | 258 | 1,937,984 | 39 | 59 | 34 | 13,580 |
| VARCHAR col | 250 | 2,000,000 | 44 | 61 | 44 | 13,580 |

- Write: **25% faster** than JSON, **23% faster** than VARCHAR
- Read speedup: **2.4x** filter, **3.5x** group by, **2.4x** scan vs JSON
- Disk: **2.8x** smaller

### Key takeaway

At 100k rows, RawDuck pays ~25-33% write overhead for shredding but reads 1.6-2.6x faster and uses 2x less disk. At 500k+ rows, columnar compression amortizes the shredding cost — RawDuck writes **25% faster** than opaque storage while reading 2.4-3.5x faster and using 2.8x less disk.

## Test plan

- [x] All 663 sqllogic test assertions pass (8 test cases, 2 skipped: quack, grpc)
- [x] Build clean (`GEN=ninja make release`, all targets)
- [x] 100k + 500k storage type comparison validates correctness (row counts match)
- [x] Based on current `main` (post PR #5 merge)