### PR TITLE
Bump DuckDB submodule and CI to v1.5.4 (Variegata)

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -26,11 +26,11 @@ jobs:
     name: Build extension binaries
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5-variegata
     with:
-      duckdb_version: v1.5.3
+      duckdb_version: v1.5.4
       ci_tools_version: v1.5-variegata
       extension_name: rawduck
       # Windows is excluded until the VS2026 runner image is compatible with
-      # duckdb v1.5.3's vendored fmt (stdext::checked_array_iterator was
+      # duckdb v1.5.4's vendored fmt (stdext::checked_array_iterator was
       # removed from the MSVC STL).
       exclude_archs: 'windows_amd64;windows_arm64;windows_amd64_mingw;windows_amd64_rtools'
 
@@ -38,7 +38,7 @@ jobs:
     name: Code Quality Check
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@v1.5-variegata
     with:
-      duckdb_version: v1.5.3
+      duckdb_version: v1.5.4
       ci_tools_version: v1.5-variegata
       extension_name: rawduck
       format_checks: 'format;tidy'

--- a/.github/workflows/QuackIntegration.yml
+++ b/.github/workflows/QuackIntegration.yml
@@ -23,12 +23,12 @@ jobs:
     name: rawduck:quack (linux_amd64)
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5-variegata
     with:
-      duckdb_version: v1.5.3
+      duckdb_version: v1.5.4
       ci_tools_version: v1.5-variegata
       extension_name: rawduck
       opt_in_archs: 'linux_amd64'
       use_merged_vcpkg_manifest: '1'
-      # Same Windows exclusion as MainDistributionPipeline: duckdb v1.5.3 fmt vs MSVC STL.
+      # Same Windows exclusion as MainDistributionPipeline: duckdb v1.5.4 fmt vs MSVC STL.
       exclude_archs: 'windows_amd64;windows_arm64;windows_amd64_mingw;windows_amd64_rtools'
       extra_extension_config: |
         duckdb_extension_load(httpfs

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -11,7 +11,7 @@
 # One-time setup: repo Settings -> Pages -> Build and deployment -> Source: GitHub Actions.
 #
 # Layout after deploy:
-#   https://quackscience.github.io/rawduck/v1.5.3/linux_amd64/rawduck.duckdb_extension.gz
+#   https://quackscience.github.io/rawduck/v1.5.4/linux_amd64/rawduck.duckdb_extension.gz
 #
 # Users:
 #   SET allow_unsigned_extensions = true;
@@ -47,7 +47,7 @@ concurrency:
 
 env:
   EXT_NAME: rawduck
-  DUCKDB_VERSION: v1.5.3
+  DUCKDB_VERSION: v1.5.4
   PAGES_BASE_URL: https://quackscience.github.io/rawduck
 
 jobs:
@@ -55,7 +55,7 @@ jobs:
     name: Build extension binaries
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5-variegata
     with:
-      duckdb_version: v1.5.3
+      duckdb_version: v1.5.4
       ci_tools_version: v1.5-variegata
       extension_name: rawduck
       # build exactly the four published platforms: linux/osx x amd64/arm64.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ real typed columns at ingest (one-time cost) so every query runs at native colum
 instead of storing opaque JSON strings and paying `->>` extraction on every scan (45–265× slower,
 see BENCHMARK.md).
 
-Pinned to DuckDB **v1.5.3**: the `duckdb/` submodule commit and the versions in
+Pinned to DuckDB **v1.5.4** (Variegata): the `duckdb/` submodule commit and the versions in
 `.github/workflows/MainDistributionPipeline.yml` must stay in sync. Build with `GEN=ninja make
 release`; test with `./build/release/test/unittest --test-dir . "test/sql/*"`; format with
 `make format-fix` (CI enforces it).

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -7,7 +7,7 @@ traces) — with the GH Archive run kept below as a historical wide-schema stres
 
 ## OTEL ingestion (primary)
 
-Published results — Apple Silicon, 10 cores, DuckDB v1.5.3, 1,000,000 records per signal, OTLP/JSON
+Published results — Apple Silicon, 10 cores, DuckDB v1.5.4, 1,000,000 records per signal, OTLP/JSON
 export envelopes (the exact bytes an OpenTelemetry Collector posts to an OTLP/HTTP json endpoint),
 default settings (no tuning):
 
@@ -101,7 +101,7 @@ One hour of real [GH Archive](https://www.gharchive.org/) data — 247,199 event
 exploding to a **914-column** schema. This is the worst case for shredding (extreme, sparse schema
 churn), kept as a stress test rather than the representative workload.
 
-Published results (Apple Silicon, 10 cores, DuckDB v1.5.3):
+Published results (Apple Silicon, 10 cores, DuckDB v1.5.4):
 
 | | JSON column | RawDuck | |
 |---|---:|---:|---|
@@ -176,7 +176,7 @@ SET rawduck_use_projections = true; -- transparent rewrite of eligible count(*) 
 - The shell reports query times with `.timer on`; dot-commands don't work via `duckdb -c`, use
   `-f script.sql`.
 - A shallow duckdb submodule clone without tags makes the shell report `v0.0.1`; fetch the release
-  tag (`git -C duckdb fetch --depth 1 origin tag v1.5.3`) or extension installs 404.
+  tag (`git -C duckdb fetch --depth 1 origin tag v1.5.4`) or extension installs 404.
 - For large imports where each line is a fat container (OTLP envelopes, CloudWatch log groups), the
   loader auto-parallelizes via byte-aware batching; you only need `batch_size` to *raise* the line
   cap for very small flat records.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ want to project or filter their result columns.
 ## Benchmark: OTEL at line speed
 
 Real OTLP/JSON export envelopes — logs, metrics, traces — shredded into typed columns on
-ingest. Apple Silicon, DuckDB v1.5.3, 1M records per signal:
+ingest. Apple Silicon, DuckDB v1.5.4, 1M records per signal:
 
 | signal | records | columns | source NDJSON | ingest | records/s | throughput | on disk |
 |---|---:|---:|---:|---:|---:|---:|---:|

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -2,7 +2,7 @@
 
 Use [`@rawtree/mcp`](https://github.com/rawtreedb/rawtree-mcp) as an MCP client for RawDuck's HTTP API (`raw_serve`). Point it at your local server with `--api-url` — the core ingest/query/table tools work; hosted-only tools (logs, API keys, URL ingest) do not.
 
-**Requirements:** DuckDB 1.5.3 or higher with the RawDuck extension loaded, Node.js ≥ 22.
+**Requirements:** DuckDB 1.5.4 or higher with the RawDuck extension loaded, Node.js ≥ 22.
 
 ## Setup
 

--- a/docs/SDK.md
+++ b/docs/SDK.md
@@ -2,7 +2,7 @@
 
 Use [`@rawtree/sdk`](https://www.npmjs.com/package/@rawtree/sdk) against RawDuck's HTTP API (`raw_serve`). Point the client at your local server with `baseUrl` — insert, query, and table metadata responses match the public API shape.
 
-**Requirements:** DuckDB 1.5.3 or higher with the RawDuck extension loaded, Node.js with `fetch` (≥ 18).
+**Requirements:** DuckDB 1.5.4 or higher with the RawDuck extension loaded, Node.js with `fetch` (≥ 18).
 
 ## Setup
 


### PR DESCRIPTION
Keep extension-ci-tools on v1.5-variegata; update docs and release paths to match.