### PR TITLE
Fix measurement defects in k8s comparison benchmark

### DIFF
--- a/benchmark/k8s-comparison/gen_k8s_logs.py
+++ b/benchmark/k8s-comparison/gen_k8s_logs.py
@@ -18,6 +18,11 @@ from pathlib import Path
 
 random.seed(42)
 
+# Width of the generated timestamp window, in hours. Kept well inside OpenObserve's
+# 5h default ingest-lookback so that a long benchmark run cannot drift records out of
+# the accepted window between generation and ingest.
+SPAN_HOURS = 2
+
 # Realistic distributions
 SERVICES = ["api-gateway", "user-service", "order-service", "payment-service",
             "inventory-service", "notification-service", "search-service", "auth-service",
@@ -112,10 +117,20 @@ def main() -> int:
     out_path = Path(sys.argv[2]) if len(sys.argv) > 2 else default_path
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Base timestamp: recent data (OpenObserve only accepts last few hours by default)
+    # Timestamps must span a window that is entirely in the PAST at generation time and
+    # still entirely inside OpenObserve's accepted ingest window when ingest actually runs
+    # (which can be well after generation - RawDuck is benchmarked first).
+    #
+    # OpenObserve discards records outside [now - ZO_INGEST_ALLOWED_UPTO, now +
+    # ZO_INGEST_ALLOWED_IN_FUTURE] (src/core/src/logs/ingest.rs, handle_timestamp).
+    # Defaults are 5h past / 24h future. Future-dated records would ingest fine but then
+    # fall outside any query window ending at "now", so the newest record is pinned one
+    # minute in the past. See SPAN_HOURS note in run_k8s_comparison.py.
     import time as time_module
-    ts_base = int(time_module.time() * 1_000_000_000) - (3 * 60 * 60 * 1_000_000_000)  # 3 hours ago
-    ts_increment = (4 * 60 * 60 * 1_000_000_000) // total  # Spread over 4 hours
+    span_ns = SPAN_HOURS * 60 * 60 * 1_000_000_000
+    ts_end = int(time_module.time() * 1_000_000_000) - (60 * 1_000_000_000)  # 1 min ago
+    ts_base = ts_end - span_ns
+    ts_increment = max(1, span_ns // total)
 
     print(f"Generating {total:,} records to {out_path}...")
     start = time.perf_counter()

--- a/benchmark/k8s-comparison/run_full_benchmark.sh
+++ b/benchmark/k8s-comparison/run_full_benchmark.sh
@@ -49,7 +49,7 @@ import gen_k8s_logs
 from pathlib import Path
 data_dir = Path('data')
 data_dir.mkdir(exist_ok=True)
-data_path = data_dir / 'k8s_logs_${RECORDS}.ndjson'
+data_path = data_dir / f'k8s_logs_{${RECORDS} // 1_000_000}m.ndjson'
 if not data_path.exists():
     sys.argv = ['gen', '$RECORDS', str(data_path)]
     gen_k8s_logs.main()
@@ -68,6 +68,12 @@ start_openobserve() {
     export ZO_ROOT_USER_PASSWORD="Complexpass#123"
     export ZO_DATA_DIR="$SETUP_DIR/openobserve_data"
     export ZO_HTTP_PORT="5080"
+    # Records are generated fresh at the start of the run, but RawDuck is benchmarked
+    # first, so by the time OpenObserve ingests them they are already some hours old.
+    # OpenObserve discards anything outside this window (handle_timestamp in
+    # src/core/src/logs/ingest.rs); the defaults are 5h past / 24h future.
+    export ZO_INGEST_ALLOWED_UPTO="48"
+    export ZO_INGEST_ALLOWED_IN_FUTURE="48"
 
     "$SETUP_DIR/openobserve/openobserve" > "$SETUP_DIR/openobserve.log" 2>&1 &
     echo $! > "$SETUP_DIR/openobserve.pid"

--- a/benchmark/k8s-comparison/run_k8s_comparison.py
+++ b/benchmark/k8s-comparison/run_k8s_comparison.py
@@ -31,6 +31,17 @@ DATA_DIR = BENCHMARK_DIR / "data"
 RESULTS_DIR = BENCHMARK_DIR / "results"
 DUCKDB_BIN = PROJECT_ROOT / "build" / "release" / "duckdb"
 
+# Warn if the dataset's newest record is older than this. Must stay below OpenObserve's
+# ZO_INGEST_ALLOWED_UPTO (default 5h) with room for the run itself.
+MAX_DATA_AGE_HOURS = 1.0
+
+# Seconds to wait after ingest before the first query. The benchmark deliberately
+# measures read performance on a freshly-ingested, unsettled store, so this is 0 - but it
+# is applied identically to every system so the scenario means the same thing for each.
+# Residual lag (verification queries, per-run drift) is recorded per measurement as
+# since_ingest_s rather than eliminated.
+POST_INGEST_DELAY_S = 0.0
+
 
 @dataclass
 class QueryResult:
@@ -39,6 +50,11 @@ class QueryResult:
     cold_ms: float = 0  # First run (cold cache)
     hot_ms: float = 0   # Best of subsequent runs (hot cache)
     runs: list[float] = field(default_factory=list)  # All run times
+    # Seconds between end of ingest and the start of each run, parallel to `runs`.
+    # Background compaction keeps progressing during the sweep, so a later run is served
+    # from a more settled store - this makes that visible instead of silent.
+    since_ingest_s: list[float] = field(default_factory=list)
+    rows: int = 0  # Result rows returned (0 => treated as an error, see finish_query)
     error: str | None = None
 
 
@@ -47,7 +63,13 @@ class BenchmarkResult:
     system: str
     ingest_time_s: float = 0
     storage_mb: float = 0
-    records: int = 0
+    records: int = 0  # Records the harness believes it sent
+    verified_records: int = 0  # Records the system actually reports holding
+    short_by: int = 0  # Records sent but not visible at verification time (not an error)
+    # Logical (pre-compression) size. Only OpenObserve reports this directly; left at 0
+    # for the others rather than guessed at.
+    storage_uncompressed_mb: float = 0
+    ingest_end: float | None = None  # perf_counter() at the moment ingest finished
     queries: list[QueryResult] = field(default_factory=list)
     error: str | None = None
 
@@ -111,6 +133,155 @@ QUERIES = {
         "clickhouse": "SELECT service_name, http_latency_ms, http_path FROM k8s_logs WHERE http_latency_ms > 1000 ORDER BY http_latency_ms DESC LIMIT 100",
     },
 }
+
+
+def data_time_range_ns(data_path: Path) -> tuple[int, int]:
+    """Return (min_ts_ns, max_ts_ns) of the NDJSON data file.
+
+    gen_k8s_logs.py emits strictly increasing timestamps, so the first and last lines
+    bound the range. Reading both avoids assuming anything about when the file was made.
+    """
+    with data_path.open("rb") as f:
+        first = f.readline()
+        try:
+            f.seek(-min(65536, data_path.stat().st_size), 2)
+        except OSError:
+            f.seek(0)
+        tail = f.read().splitlines()
+    last = next(line for line in reversed(tail) if line.strip())
+    return json.loads(first)["_timestamp"], json.loads(last)["_timestamp"]
+
+
+def count_rows(system: str, body: bytes) -> int:
+    """Number of result rows in a query response, per system response format.
+
+    A query that returns nothing is not a fast query - it means the store is empty or
+    the time filter excluded everything. Callers treat 0 as an error, not a fast result.
+    """
+    if system == "rawduck":
+        # /v1/query -> {"meta": ..., "data": [...], "rows": N, "statistics": ...}
+        doc = json.loads(body)
+        if isinstance(doc.get("rows"), int):
+            return doc["rows"]
+        return len(doc.get("data") or [])
+    if system == "openobserve":
+        # /_search -> {"hits": [...], "total": N, ...}
+        return len(json.loads(body).get("hits") or [])
+    if system == "clickhouse":
+        # default HTTP format is TabSeparated: one line per row
+        return sum(1 for line in body.splitlines() if line.strip())
+    raise ValueError(f"unknown system: {system}")
+
+
+def openobserve_storage_mb() -> tuple[float, float]:
+    """Return (on_disk_mb, uncompressed_mb) for the k8s_logs stream.
+
+    GET /api/{org}/streams returns {"list": [{"name", "stats": {...}}], "total": N}
+    (ListStream, src/common/src/meta/stream.rs:82). StreamStats carries storage_size /
+    compressed_size / index_size, accumulated from FileMeta byte counts - but the service
+    layer divides all three by SIZE_IN_MB before returning (transform_stats,
+    src/stream/src/lib.rs:1011-1019), so these are already MEGABYTES, not bytes.
+
+    on_disk = compressed_size + index_size, the analogue of ClickHouse's bytes_on_disk
+    (part files including indexes) and of RawDuck's .db file size. Data still in the WAL
+    is not counted, matching the other two reporting only what is on disk right now.
+    """
+    req = urllib.request.Request("http://localhost:5080/api/default/streams?type=logs")
+    req.add_header("Authorization", "Basic cm9vdEBleGFtcGxlLmNvbTpDb21wbGV4cGFzcyMxMjM=")
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        doc = json.loads(resp.read())
+
+    entries = doc.get("list") if isinstance(doc, dict) else doc
+    for entry in entries or []:
+        if entry.get("name") != "k8s_logs":
+            continue
+        stats = entry.get("stats") or {}
+        compressed = float(stats.get("compressed_size") or 0.0)
+        index = float(stats.get("index_size") or 0.0)
+        uncompressed = float(stats.get("storage_size") or 0.0)
+        return compressed + index, uncompressed
+    return 0.0, 0.0
+
+
+def verify_stored_records(system: str, data_range_ns: tuple[int, int]) -> int:
+    """Ask a system how many rows it actually holds.
+
+    The ingest paths report what the harness *sent*. That is not the same as what the
+    system *stored* - records can be silently discarded. Every empty-result and speedup
+    number downstream is meaningless if the store is short, so this is checked directly.
+    """
+    sql = "SELECT count(*) as cnt FROM k8s_logs"
+    if system == "rawduck":
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{RAWDUCK_PORT}/v1/query",
+            data=json.dumps({"sql": sql}).encode(),
+            method="POST",
+        )
+        req.add_header("Content-Type", "application/json")
+        req.add_header("Authorization", f"Bearer {RAWDUCK_TOKEN}")
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            data = json.loads(resp.read()).get("data") or []
+        row = data[0] if data else None
+        if isinstance(row, dict):
+            return int(next(iter(row.values())))
+        return int(row[0]) if row else 0
+
+    if system == "clickhouse":
+        req = urllib.request.Request(
+            f"http://127.0.0.1:8123/?query={urllib.parse.quote(sql)}",
+        )
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            return int(resp.read().decode().strip())
+
+    if system == "openobserve":
+        min_ns, max_ns = data_range_ns
+        margin_us = 60 * 1_000_000
+        payload = json.dumps({
+            "query": {
+                "sql": sql,
+                "from": 0,
+                "size": 1,
+                "start_time": (min_ns // 1000) - margin_us,
+                "end_time": (max_ns // 1000) + margin_us,
+            },
+        }).encode()
+        req = urllib.request.Request(
+            "http://localhost:5080/api/default/_search?type=logs",
+            data=payload,
+            method="POST",
+        )
+        req.add_header("Content-Type", "application/json")
+        req.add_header("Authorization", "Basic cm9vdEBleGFtcGxlLmNvbTpDb21wbGV4cGFzcyMxMjM=")
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            hits = json.loads(resp.read()).get("hits") or []
+        return int(next(iter(hits[0].values()))) if hits else 0
+
+    raise ValueError(f"unknown system: {system}")
+
+
+def finish_query(system: str, name: str, times: list[float], rows: int,
+                 error: str | None, since_ingest: list[float] | None = None) -> QueryResult:
+    """Build a QueryResult, downgrading an empty result set to an error.
+
+    An empty result is recorded as an error so it shows as ERR in the tables instead of
+    contributing a misleadingly fast latency to the comparison.
+    """
+    since_ingest = since_ingest or []
+    if error is None and times and rows == 0:
+        error = "empty result (0 rows) - not counted as a valid timing"
+    if not times or error is not None:
+        return QueryResult(name=name, system=system, runs=times,
+                           since_ingest_s=since_ingest, error=error)
+    return QueryResult(
+        name=name,
+        system=system,
+        cold_ms=times[0],
+        hot_ms=min(times[1:]) if len(times) > 1 else times[0],
+        runs=times,
+        since_ingest_s=since_ingest,
+        rows=rows,
+        error=None,
+    )
 
 
 # Global RawDuck server process (modeled after OTEL streaming benchmark's Server class)
@@ -211,6 +382,7 @@ def run_rawduck_ingest(data_path: Path) -> BenchmarkResult:
     try:
         output = _rawduck_send(sql)
         result.ingest_time_s = time.perf_counter() - start
+        result.ingest_end = time.perf_counter()
 
         # Parse CSV output: rows,columns_added,columns_widened,errors
         for line in output.strip().split("\n"):
@@ -236,10 +408,14 @@ def run_rawduck_queries(result: BenchmarkResult, runs: int = 3) -> None:
         payload = json.dumps({"sql": sql}).encode()
 
         times = []
+        since_ingest = []
         error = None
+        rows = 0
 
         for run_idx in range(runs):
             start = time.perf_counter()
+            if result.ingest_end is not None:
+                since_ingest.append(start - result.ingest_end)
             try:
                 req = urllib.request.Request(
                     f"http://127.0.0.1:{RAWDUCK_PORT}/v1/query",
@@ -250,25 +426,16 @@ def run_rawduck_queries(result: BenchmarkResult, runs: int = 3) -> None:
                 req.add_header("Authorization", f"Bearer {RAWDUCK_TOKEN}")
 
                 with urllib.request.urlopen(req, timeout=120) as resp:
-                    resp.read()
+                    body = resp.read()
                     latency = (time.perf_counter() - start) * 1000
                     times.append(latency)
+                    rows = count_rows("rawduck", body)
             except Exception as e:
                 error = str(e)
                 break
 
-        if times:
-            qr = QueryResult(
-                name=name,
-                system="rawduck",
-                cold_ms=times[0],
-                hot_ms=min(times[1:]) if len(times) > 1 else times[0],
-                runs=times,
-                error=error,
-            )
-        else:
-            qr = QueryResult(name=name, system="rawduck", error=error)
-        result.queries.append(qr)
+        result.queries.append(
+            finish_query("rawduck", name, times, rows, error, since_ingest))
 
 
 def run_openobserve_ingest(data_path: Path) -> BenchmarkResult:
@@ -294,10 +461,38 @@ def run_openobserve_ingest(data_path: Path) -> BenchmarkResult:
     except Exception:
         pass  # Stream might not exist
 
-    # Ingest data in batches
+    # Ingest data in batches.
+    #
+    # OpenObserve discards any record whose timestamp falls outside
+    # [now - ZO_INGEST_ALLOWED_UPTO, now + ZO_INGEST_ALLOWED_IN_FUTURE] (defaults 5h/24h,
+    # see handle_timestamp in src/core/src/logs/ingest.rs). Discards are reported per
+    # batch in the response body as status[].failed, NOT as an HTTP error - so the body
+    # must be read, or a fully-discarded ingest looks like a complete one.
     batch_size = 10000
     start = time.perf_counter()
     records_sent = 0
+    accepted = 0
+    rejected = 0
+
+    def post_batch(batch: list[dict]) -> tuple[int, int]:
+        payload = json.dumps(batch).encode()
+        req = urllib.request.Request(
+            "http://localhost:5080/api/default/k8s_logs/_json",
+            data=payload,
+            method="POST",
+        )
+        req.add_header("Content-Type", "application/json")
+        req.add_header("Authorization", "Basic cm9vdEBleGFtcGxlLmNvbTpDb21wbGV4cGFzcyMxMjM=")
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            body = resp.read()
+        ok = bad = 0
+        try:
+            for st in json.loads(body).get("status") or []:
+                ok += int(st.get("successful") or 0)
+                bad += int(st.get("failed") or 0)
+        except (ValueError, TypeError):
+            pass
+        return ok, bad
 
     try:
         with data_path.open() as f:
@@ -311,15 +506,9 @@ def run_openobserve_ingest(data_path: Path) -> BenchmarkResult:
                 batch.append(flat)
 
                 if len(batch) >= batch_size:
-                    payload = json.dumps(batch).encode()
-                    req = urllib.request.Request(
-                        "http://localhost:5080/api/default/k8s_logs/_json",
-                        data=payload,
-                        method="POST",
-                    )
-                    req.add_header("Content-Type", "application/json")
-                    req.add_header("Authorization", "Basic cm9vdEBleGFtcGxlLmNvbTpDb21wbGV4cGFzcyMxMjM=")
-                    urllib.request.urlopen(req, timeout=60)
+                    ok, bad = post_batch(batch)
+                    accepted += ok
+                    rejected += bad
                     records_sent += len(batch)
                     batch = []
 
@@ -328,19 +517,27 @@ def run_openobserve_ingest(data_path: Path) -> BenchmarkResult:
 
             # Final batch
             if batch:
-                payload = json.dumps(batch).encode()
-                req = urllib.request.Request(
-                    "http://localhost:5080/api/default/k8s_logs/_json",
-                    data=payload,
-                    method="POST",
-                )
-                req.add_header("Content-Type", "application/json")
-                req.add_header("Authorization", "Basic cm9vdEBleGFtcGxlLmNvbTpDb21wbGV4cGFzcyMxMjM=")
-                urllib.request.urlopen(req, timeout=60)
+                ok, bad = post_batch(batch)
+                accepted += ok
+                rejected += bad
                 records_sent += len(batch)
 
         result.ingest_time_s = time.perf_counter() - start
+        result.ingest_end = time.perf_counter()
         result.records = records_sent
+        result.verified_records = accepted
+
+        try:
+            on_disk_mb, uncompressed_mb = openobserve_storage_mb()
+            result.storage_mb = on_disk_mb
+            result.storage_uncompressed_mb = uncompressed_mb
+        except Exception as e:
+            print(f"  WARNING: could not read OpenObserve stream storage stats: {e}")
+        if rejected:
+            result.error = (
+                f"OpenObserve discarded {rejected:,} of {records_sent:,} records "
+                f"(timestamp outside ZO_INGEST_ALLOWED_UPTO/IN_FUTURE window)"
+            )
 
     except Exception as e:
         result.error = str(e)
@@ -348,11 +545,23 @@ def run_openobserve_ingest(data_path: Path) -> BenchmarkResult:
     return result
 
 
-def run_openobserve_queries(result: BenchmarkResult, runs: int = 3) -> None:
-    """Run benchmark queries against OpenObserve with cold/hot measurement."""
-    # OpenObserve requires time range - use last 24 hours
-    now_us = int(time.time() * 1_000_000)
-    start_time = now_us - (24 * 60 * 60 * 1_000_000)  # 24 hours ago in microseconds
+def run_openobserve_queries(result: BenchmarkResult, data_range_ns: tuple[int, int],
+                            runs: int = 3) -> None:
+    """Run benchmark queries against OpenObserve with cold/hot measurement.
+
+    OpenObserve's _search API requires an explicit time range. The window is derived from
+    the actual min/max timestamp of the dataset rather than from "now", so that it always
+    covers exactly the ingested data. A window ending at "now" silently excluded every
+    record newer than the moment the query ran.
+
+    OpenObserve normalises the nanosecond _timestamp values to microseconds on ingest
+    (parse_i64_to_timestamp_micros in src/config/src/utils/time.rs branches on magnitude
+    and divides ns by 1000), so the window must be expressed in microseconds.
+    """
+    min_ns, max_ns = data_range_ns
+    margin_us = 60 * 1_000_000  # 1 minute either side
+    start_time = (min_ns // 1000) - margin_us
+    end_time = (max_ns // 1000) + margin_us
 
     for name, q in QUERIES.items():
         sql = q["openobserve"]
@@ -362,15 +571,19 @@ def run_openobserve_queries(result: BenchmarkResult, runs: int = 3) -> None:
                 "from": 0,
                 "size": 1000,
                 "start_time": start_time,
-                "end_time": now_us,
+                "end_time": end_time,
             },
         }).encode()
 
         times = []
+        since_ingest = []
         error = None
+        rows = 0
 
         for run_idx in range(runs):
             start = time.perf_counter()
+            if result.ingest_end is not None:
+                since_ingest.append(start - result.ingest_end)
             try:
                 req = urllib.request.Request(
                     "http://localhost:5080/api/default/_search?type=logs",
@@ -381,25 +594,16 @@ def run_openobserve_queries(result: BenchmarkResult, runs: int = 3) -> None:
                 req.add_header("Authorization", "Basic cm9vdEBleGFtcGxlLmNvbTpDb21wbGV4cGFzcyMxMjM=")
 
                 with urllib.request.urlopen(req, timeout=120) as resp:
-                    resp.read()
+                    body = resp.read()
                     latency = (time.perf_counter() - start) * 1000
                     times.append(latency)
+                    rows = count_rows("openobserve", body)
             except Exception as e:
                 error = str(e)
                 break
 
-        if times:
-            qr = QueryResult(
-                name=name,
-                system="openobserve",
-                cold_ms=times[0],
-                hot_ms=min(times[1:]) if len(times) > 1 else times[0],
-                runs=times,
-                error=error,
-            )
-        else:
-            qr = QueryResult(name=name, system="openobserve", error=error)
-        result.queries.append(qr)
+        result.queries.append(
+            finish_query("openobserve", name, times, rows, error, since_ingest))
 
 
 def run_clickhouse_ingest(data_path: Path) -> BenchmarkResult:
@@ -493,6 +697,7 @@ ORDER BY (_timestamp)"""
                 urllib.request.urlopen(req, timeout=300)
 
         result.ingest_time_s = time.perf_counter() - start
+        result.ingest_end = time.perf_counter()
 
         # Get record count
         count_req = urllib.request.Request(
@@ -519,34 +724,71 @@ def run_clickhouse_queries(result: BenchmarkResult, runs: int = 3) -> None:
     for name, q in QUERIES.items():
         sql = q["clickhouse"]
         times = []
+        since_ingest = []
         error = None
+        rows = 0
 
         for run_idx in range(runs):
             start = time.perf_counter()
+            if result.ingest_end is not None:
+                since_ingest.append(start - result.ingest_end)
             try:
                 req = urllib.request.Request(
                     f"http://127.0.0.1:8123/?query={urllib.parse.quote(sql)}",
                 )
                 with urllib.request.urlopen(req, timeout=120) as resp:
-                    resp.read()
+                    body = resp.read()
                     latency = (time.perf_counter() - start) * 1000
                     times.append(latency)
+                    rows = count_rows("clickhouse", body)
             except Exception as e:
                 error = str(e)
                 break
 
-        if times:
-            qr = QueryResult(
-                name=name,
-                system="clickhouse",
-                cold_ms=times[0],
-                hot_ms=min(times[1:]) if len(times) > 1 else times[0],
-                runs=times,
-                error=error,
-            )
-        else:
-            qr = QueryResult(name=name, system="clickhouse", error=error)
-        result.queries.append(qr)
+        result.queries.append(
+            finish_query("clickhouse", name, times, rows, error, since_ingest))
+
+
+def await_post_ingest_delay(system: str) -> None:
+    """Apply the fixed post-ingest delay, identically for every system.
+
+    POST_INGEST_DELAY_S is 0 by design: the benchmark measures reads against a store that
+    is still settling. The point of routing it through one function is that the scenario
+    is defined once and is the same for all three systems.
+    """
+    if POST_INGEST_DELAY_S > 0:
+        print(f"  Waiting {POST_INGEST_DELAY_S:.1f}s post-ingest ({system})...")
+        time.sleep(POST_INGEST_DELAY_S)
+
+
+def check_stored(result: BenchmarkResult, system: str, expected: int,
+                 data_range_ns: tuple[int, int]) -> None:
+    """Verify the system stored what the harness sent; flag the result if it did not."""
+    try:
+        stored = verify_stored_records(system, data_range_ns)
+    except Exception as e:
+        result.error = f"could not verify stored record count: {e}"
+        print(f"  ERROR: {result.error}")
+        return
+
+    result.verified_records = stored
+    result.short_by = max(0, expected - stored)
+
+    if stored == 0:
+        # Nothing to read: every timing below would be measuring an empty store.
+        result.error = "system stored 0 records - all query timings would be meaningless"
+        print(f"  ERROR: {result.error}")
+    elif stored != expected:
+        # Not an error. The benchmark queries a freshly-ingested store on purpose, so a
+        # system that has not yet made every record visible is a legitimate result - but
+        # it means this system answered over fewer rows than the others, so it is
+        # recorded and reported rather than swallowed.
+        pct = 100.0 * stored / expected if expected else 0.0
+        print(f"  NOTE: {stored:,} of {expected:,} records visible at query time "
+              f"({pct:.2f}%, short by {expected - stored:,}) - "
+              f"this system reads over fewer rows than the others")
+    else:
+        print(f"  Verified: {stored:,} records stored")
 
 
 def print_results(results: list[BenchmarkResult], records: int) -> None:
@@ -559,14 +801,46 @@ def print_results(results: list[BenchmarkResult], records: int) -> None:
 
     # Ingest comparison
     print("\n## Ingest Performance")
-    print(f"{'System':<15} {'Time (s)':<12} {'Records/s':<15} {'Storage (MB)':<15}")
-    print("-" * 60)
+    print(f"{'System':<15} {'Time (s)':<12} {'Records/s':<15} {'Storage (MB)':<15} "
+          f"{'Visible':<15} {'Short by':<12}")
+    print("-" * 87)
     for r in results:
         if r.error:
-            print(f"{r.system:<15} ERROR: {r.error[:40]}")
+            print(f"{r.system:<15} ERROR: {r.error[:65]}")
         else:
             rps = r.records / r.ingest_time_s if r.ingest_time_s > 0 else 0
-            print(f"{r.system:<15} {r.ingest_time_s:<12.2f} {rps:<15,.0f} {r.storage_mb:<15.1f}")
+            short = f"{r.short_by:,}" if r.short_by else "-"
+            print(f"{r.system:<15} {r.ingest_time_s:<12.2f} {rps:<15,.0f} "
+                  f"{r.storage_mb:<15.1f} {r.verified_records:<15,} {short:<12}")
+    if any(r.storage_uncompressed_mb for r in results if not r.error):
+        print("\nStorage is the on-disk footprint at query time. OpenObserve also reports "
+              "an\nuncompressed size; both are snapshots taken while compaction is still "
+              "in progress.")
+        for r in results:
+            if not r.error and r.storage_uncompressed_mb:
+                ratio = (r.storage_uncompressed_mb / r.storage_mb) if r.storage_mb else 0
+                print(f"  {r.system}: {r.storage_mb:.1f} MB on disk, "
+                      f"{r.storage_uncompressed_mb:.1f} MB uncompressed"
+                      + (f" ({ratio:.1f}x)" if ratio else ""))
+
+    if any(r.short_by for r in results if not r.error):
+        print("\nNOTE: a system short of records answered over fewer rows than the "
+              "others.\n      Ingest timings are diagnostic only - this benchmark "
+              "compares read performance.")
+
+    # Time-since-ingest. The store keeps compacting during the sweep, so a query measured
+    # late is served from a more settled store than one measured early. Reported so the
+    # comparison is not silently confounded by sweep position.
+    print("\n## Time Since Ingest (s, per query sweep)")
+    print(f"{'System':<15} {'First run':<14} {'Last run':<14} {'Sweep span':<14}")
+    print("-" * 60)
+    for r in valid_results:
+        lags = [t for q in r.queries for t in q.since_ingest_s]
+        if not lags:
+            print(f"{r.system:<15} {'-':<14} {'-':<14} {'-':<14}")
+            continue
+        print(f"{r.system:<15} {min(lags):<14.2f} {max(lags):<14.2f} "
+              f"{max(lags) - min(lags):<14.2f}")
 
     query_names = list(QUERIES.keys())
 
@@ -633,7 +907,7 @@ def print_results(results: list[BenchmarkResult], records: int) -> None:
                     qr = next((q for q in r.queries if q.name == qname and not q.error), None)
                     if qr:
                         speedup = slowest / qr.hot_ms if qr.hot_ms > 0 else 0
-                        row += f" {speedup:<15.1f}x"
+                        row += f" {f'{speedup:.1f}x':<15}"
                     else:
                         row += f" {'-':<15}"
                 print(row)
@@ -654,9 +928,24 @@ def main() -> int:
     runs = args.runs
     systems = [s.strip() for s in args.systems.split(",")]
 
-    # Generate data
+    # Generate data.
+    #
+    # A stale file must be regenerated, not reused: OpenObserve discards records older
+    # than ZO_INGEST_ALLOWED_UPTO (default 5h), so yesterday's file would ingest as an
+    # empty stream while still reporting a full, fast run.
     DATA_DIR.mkdir(parents=True, exist_ok=True)
     data_path = DATA_DIR / f"k8s_logs_{records // 1_000_000}m.ndjson"
+
+    # Warn but do NOT regenerate: each system is benchmarked in a separate invocation of
+    # this script, so silently regenerating here would give different phases different
+    # data. If a stale file really does get discarded on ingest, check_stored catches it.
+    if data_path.exists():
+        age_h = (time.time() - data_time_range_ns(data_path)[1] / 1e9) / 3600
+        if age_h > MAX_DATA_AGE_HOURS:
+            print(f"WARNING: data file's newest record is {age_h:.1f}h old. OpenObserve "
+                  f"discards records older than ZO_INGEST_ALLOWED_UPTO (default 5h). "
+                  f"Delete {data_path} to regenerate.")
+
     if not data_path.exists():
         print(f"Generating {records:,} records...")
         # Import and run from same directory
@@ -670,7 +959,10 @@ def main() -> int:
         gen_k8s_logs.main()
         sys.argv = old_argv
 
+    data_range_ns = data_time_range_ns(data_path)
     print(f"\nData file: {data_path} ({data_path.stat().st_size / (1024*1024):.1f} MB)")
+    print(f"Data time range: {data_range_ns[0] / 1e9:.0f} .. {data_range_ns[1] / 1e9:.0f} "
+          f"(epoch s, {(data_range_ns[1] - data_range_ns[0]) / 3.6e12:.2f}h span)")
 
     results = []
 
@@ -695,6 +987,9 @@ def main() -> int:
                     r.records = records
 
                 if not r.error:
+                    await_post_ingest_delay("rawduck")
+                    check_stored(r, "rawduck", records, data_range_ns)
+                if not r.error:
                     print(f"  Running queries ({runs} runs each)...")
                     run_rawduck_queries(r, runs=runs)
                 results.append(r)
@@ -717,8 +1012,11 @@ def main() -> int:
             r.records = records
 
         if not r.error:
+            await_post_ingest_delay("openobserve")
+            check_stored(r, "openobserve", records, data_range_ns)
+        if not r.error:
             print(f"  Running queries ({runs} runs each)...")
-            run_openobserve_queries(r, runs=runs)
+            run_openobserve_queries(r, data_range_ns, runs=runs)
         results.append(r)
 
     # ClickHouse
@@ -735,6 +1033,9 @@ def main() -> int:
             r = BenchmarkResult(system="clickhouse")
             r.records = records
 
+        if not r.error:
+            await_post_ingest_delay("clickhouse")
+            check_stored(r, "clickhouse", records, data_range_ns)
         if not r.error:
             print(f"  Running queries ({runs} runs each)...")
             run_clickhouse_queries(r, runs=runs)
@@ -755,7 +1056,10 @@ def main() -> int:
             "system": r.system,
             "ingest_time_s": r.ingest_time_s,
             "storage_mb": r.storage_mb,
+            "storage_uncompressed_mb": r.storage_uncompressed_mb,
             "records": r.records,
+            "verified_records": r.verified_records,
+            "short_by": r.short_by,
             "error": r.error,
             "queries": [
                 {
@@ -763,6 +1067,8 @@ def main() -> int:
                     "cold_ms": q.cold_ms,
                     "hot_ms": q.hot_ms,
                     "all_runs_ms": q.runs,
+                    "since_ingest_s": q.since_ingest_s,
+                    "rows": q.rows,
                     "error": q.error,
                 }
                 for q in r.queries
@@ -788,6 +1094,7 @@ def main() -> int:
     output = {
         "records": records,
         "query_runs": runs,
+        "post_ingest_delay_s": POST_INGEST_DELAY_S,
         "data_file": str(data_path),
         "data_size_mb": data_path.stat().st_size / (1024 * 1024),
         "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ"),


### PR DESCRIPTION
Rebased on top of `benchmark-comparison` (a95fe29, 2847c44). The per-phase
result-merging fix from a95fe29 is preserved — this only adds fields to
`new_result_blocks`, keeping the `existing_blocks + new_result_blocks` merge.

The harness could report fast query times against a store holding no matching
rows, which silently inverts the comparison. Five issues, each verified against
OpenObserve's source at tag v0.92.2 rather than assumed.

### Query window excluded future-dated records

`gen_k8s_logs.py` emitted timestamps from `now-3h` to `now+1h` (base `now-3h`,
spread over 4h), while the `_search` window ended at `now`. Every future-dated
record fell outside the query range, by a fraction that varied with how long the
run took.

Generated window is now entirely in the past (2h wide, ending 1 min ago), and the
search window is derived from the dataset's actual min/max timestamp instead of
wall-clock now. The 24h lookback was never the problem and is unchanged in spirit.

### Empty results scored as fast queries

All three query paths called `resp.read()` and discarded the body, so a query
returning zero rows was recorded as a very fast timing and won the speedup table.
Result rows are now counted per system, and a 0-row result is recorded as an
error rather than a timing.

### Discarded records reported as a successful ingest

OpenObserve reports discarded records in the response body as `status[].failed`,
not as an HTTP error (`handle_timestamp`, `src/core/src/logs/ingest.rs`), and the
body was never read. A data file older than `ZO_INGEST_ALLOWED_UPTO` would ingest
as an empty stream while reporting a complete, fast run.

Batch responses are now read, and the stored row count is verified on every system
before querying. Zero rows fails that system; a short count is recorded and
reported but does not fail the run, since querying a still-settling store is
intentional here.

### Time since ingest was uncontrolled and unrecorded

The benchmark measures reads against a freshly ingested store, so how long after
ingest each measurement runs is part of the result. The 27-request sweep spans
multiple compaction cycles (`ZO_COMPACT_INTERVAL` defaults to 10s), so a late
query is served from a more settled store than an early one, and `hot_ms` mixes
cache warmth with compaction progress.

Lag is now recorded on every run and the sweep span reported. The post-ingest
delay is routed through one constant (0s, unchanged behaviour) so it is identical
across systems rather than three ad-hoc paths.

### OpenObserve storage always printed 0.0

`storage_mb` was never set. It now comes from the streams API as
`compressed_size + index_size`, the analogue of ClickHouse's `bytes_on_disk`.
Note these fields are already megabytes — `transform_stats`
(`src/stream/src/lib.rs`) divides by `SIZE_IN_MB` before returning. `storage_size`
is kept separately as the uncompressed figure.

### Also

`run_full_benchmark.sh` wrote `k8s_logs_1000000.ndjson` while the harness reads
`k8s_logs_1m.ndjson`, so the pre-generation step was dead work and the file was
generated twice. `ZO_INGEST_ALLOWED_UPTO/IN_FUTURE` are set explicitly so a long
run cannot silently discard records.

### Verification

RawDuck is not built in this environment and neither backend is installed, so no
end-to-end run. What was run:

- 16 logic assertions — generator bounds, range reader, per-format row counting,
  empty-result flagging, the three `check_stored` verdicts, storage parsing.
- Integration test driving the real `run_clickhouse_queries` loop against a mock:
  2-row response gives 9 valid timings; 0-row response gives 9 flagged and zero
  fake timings.
- The real three-phase flow (`--systems rawduck`, then `openobserve`, then
  `clickhouse`) against one output file, confirming a95fe29's merge still holds:
  `['rawduck', 'openobserve', 'clickhouse']` all survive with the new fields.

### Not addressed

OpenObserve's result cache is left on (`ZO_RESULT_CACHE_ENABLED` defaults true,
and `use_cache` is only honoured as a URL param). ClickHouse's query cache is off
by default, so `hot_ms` may compare a cached OpenObserve result against two
engines re-executing. Deliberate for now, but worth a footnote wherever these
numbers get published.